### PR TITLE
chore: paridade com o irmao mcp-fiscal-brasil

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug Report
+description: Reporte um bug no mcp-juridico-brasil
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Descrição
+      description: Descrição clara do que está ocorrendo.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Passos para reproduzir
+      description: Passos para reproduzir o comportamento.
+      placeholder: |
+        1. Configure a tool com...
+        2. Chame a tool '...'
+        3. Veja o erro
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportamento esperado
+      description: O que você esperava que acontecesse.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: module
+    attributes:
+      label: Módulo afetado
+      options:
+        - processual
+        - monitoramento
+        - prazo
+        - jurisprudencia
+        - legislacao
+        - calculos
+        - core/server
+        - outro
+    validations:
+      required: true
+
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: Versão do Python
+      options:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Saída de erro / Logs
+      render: text

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Sugira uma nova funcionalidade ou melhoria
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Descrição
+      description: Descrição clara da funcionalidade que você gostaria de ver.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: module
+    attributes:
+      label: Módulo
+      description: A qual módulo essa funcionalidade pertenceria?
+      options:
+        - processual
+        - monitoramento
+        - prazo
+        - jurisprudencia
+        - legislacao
+        - calculos
+        - novo módulo
+        - core/server
+        - outro
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Caso de uso
+      description: Descreva o caso de uso - que problema isso resolve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternativas consideradas
+      description: Alguma abordagem alternativa que você já pensou?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Resumo
+
+<!-- Descreva o que este PR faz e por que -->
+
+## Checklist
+
+- [ ] Testes passam (`uv run pytest`)
+- [ ] Lint passa (`uv run ruff check src/ tests/`)
+- [ ] Formatação passa (`uv run ruff format --check src/ tests/`)
+- [ ] Typecheck passa (`uv run mypy src/`)
+- [ ] Nenhuma mudança que quebre interfaces existentes das tools
+- [ ] Documentação atualizada (se aplicável)
+- [ ] Texto da nota de release em pt-BR correto com acentuação

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    labels:
+      - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -12,23 +20,53 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+
+      - name: Configura Python
+        uses: actions/setup-python@v5
         with:
-          version: "latest"
-      - run: uv sync --extra dev
-      - run: uv run ruff check src tests
-      - run: uv run ruff format --check src tests
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-lint-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-lint-
+
+      - name: Instala dependencias de dev
+        run: pip install -e ".[dev]"
+
+      - name: Lint (ruff)
+        run: ruff check src/ tests/
+
+      - name: Formatacao (ruff)
+        run: ruff format --check src/ tests/
 
   typecheck:
     name: Tipagem estatica
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+
+      - name: Configura Python
+        uses: actions/setup-python@v5
         with:
-          version: "latest"
-      - run: uv sync --extra dev
-      - run: uv run mypy src
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-types-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-types-
+
+      - name: Instala dependencias de dev
+        run: pip install -e ".[dev]"
+
+      - name: Tipagem (mypy)
+        run: mypy src/
 
   test:
     name: Testes (Python ${{ matrix.python-version }})
@@ -36,14 +74,33 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+
+      - name: Configura Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          version: "latest"
-      - run: uv sync --extra dev
-      - run: uv run pytest tests/ --cov=src --cov-report=xml
-      - name: Upload cobertura
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+      - name: Instala dependencias de dev
+        run: pip install -e ".[dev]"
+
+      - name: Verifica metadados de release
+        run: python scripts/check_release_metadata.py
+
+      - name: Executa testes
+        run: pytest tests/ --cov=src --cov-report=xml
+
+      - name: Upload de cobertura
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Aprovar PR (patch e minor)
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-mergear PR (patch e minor)
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comentar em PR major (requer review humano)
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body "Este PR envolve uma atualizacao **major**. Review humano necessario antes do merge."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,39 @@
+name: Publica no Registry Oficial MCP
+
+on:
+  workflow_dispatch: {}
+  release:
+    types: [published]
+
+jobs:
+  publish-mcp-registry:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout do codigo
+        uses: actions/checkout@v4
+
+      - name: Instala mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Aguardar pacote no PyPI
+        run: |
+          VERSION=$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "Aguardando mcp-juridico-brasil==$VERSION no PyPI"
+          for i in $(seq 1 30); do
+            if curl -sfo /dev/null --connect-timeout 10 --max-time 20 "https://pypi.org/pypi/mcp-juridico-brasil/$VERSION/json"; then
+              echo "Pacote $VERSION disponivel no PyPI"; exit 0
+            fi
+            echo "Tentativa $i: ainda nao disponivel, aguardando 10s"; sleep 10
+          done
+          echo "Timeout aguardando o pacote no PyPI"; exit 1
+
+      - name: Autentica no registry MCP via OIDC do GitHub
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publica o servidor no registry MCP
+        run: ./mcp-publisher publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publicar no PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configura Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-publish-${{ hashFiles('pyproject.toml') }}
+
+      - name: Instala ferramentas de build
+        run: pip install hatchling build
+
+      - name: Constroi o pacote
+        run: python -m build
+
+      - name: Publica no PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,36 @@
+name: Welcome
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    if: ${{ !endsWith(github.actor, '[bot]') }}
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
+            Obrigado por abrir uma issue! Vamos analisar assim que possivel.
+
+            Para nos ajudar a entender o problema, inclua:
+            - Descricao clara do que aconteceu e o que era esperado
+            - Para bugs: tribunal (ex.: TJSP, STJ, TRF3), numero do processo, versao do pacote (`pip show mcp-juridico-brasil`) e passos para reproduzir
+            - Versao do Python e sistema operacional
+
+            Tem uma duvida ou sugestao mais aberta? Use o [Discussions](../../discussions) do projeto.
+          pr_message: |
+            Obrigado pela contribuicao! Agradecemos o tempo dedicado.
+
+            Antes de seguir, confira:
+            - Os testes e o lint passam localmente (`pytest` e `ruff check`)
+            - A mudanca esta descrita na descricao do PR (o que foi alterado e por que)
+            - Tribunais e modulos juridicos afetados estao mencionados, se aplicavel
+            - Nenhuma credencial ou dado de processo real foi incluido acidentalmente

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+Todas as mudanças notáveis neste projeto serão documentadas aqui.
+
+Formato baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
+versionamento seguindo [Semantic Versioning](https://semver.org/lang/pt-BR/).
+
+## [Unreleased]
+
+### Adicionado
+
+- (trabalho em andamento)
+
+## [0.1.0] - 2026-06-22
+
+### Adicionado
+
+#### Fase 1 - Consulta processual via DataJud CNJ (6 tools)
+
+- `consultar_processo` - consulta um processo pelo número CNJ unificado (NNNNNNN-DD.AAAA.J.TT.OOOO),
+  retornando dados cadastrais, classe, assunto, órgão julgador, valor da causa e situação atual.
+  Cobertura de 91 tribunais (STF, STJ, TJs, TRFs, TRTs e especializados).
+- `listar_movimentacoes` - lista as movimentações processuais com data, código CNJ de movimento
+  e complementos. Suporta cursor de navegação por offset e filtro por período.
+- `resumir_processo` - gera resumo estruturado do processo em linguagem natural: partes, pedidos,
+  fase atual, últimas movimentações e próximos passos relevantes.
+- `buscar_processos_parte` - busca processos por nome ou CPF/CNPJ de uma das partes, com filtro
+  de tribunal e classe processual.
+- `listar_tribunais` - retorna a lista de tribunais cobertos pela API DataJud com seus códigos,
+  nomes e tipos (estadual, federal, trabalhista, superior).
+- `verificar_disponibilidade_datajud` - verifica a disponibilidade da API DataJud e o status
+  do índice de cada tribunal, útil para diagnóstico antes de consultas em lote.
+
+#### Fase 2 - Cálculo de prazo e resources de monitoramento
+
+- `calcular_prazo` - calcula o prazo processual a partir de uma data-base, considerando
+  dias úteis, feriados nacionais, estaduais e recessos forenses configuráveis por tribunal.
+  Usa `workalendar` para calendário de feriados brasileiro. Retorna data de vencimento,
+  dias úteis percorridos e lista de dias não computados com justificativa.
+- `verificar_prazo_vencimento` - verifica se um prazo está dentro do alerta (configurável,
+  padrão 3 dias úteis) ou já vencido, retornando status semáforo (ok, alerta, vencido).
+- Resource `processo://{numero_cnj}` - resource MCP de acompanhamento: retorna snapshot
+  atualizado do processo a cada leitura, adequado para monitoramento periódico por clientes MCP.
+- Resource `movimentacoes://{numero_cnj}` - resource MCP com as últimas movimentações do
+  processo, com suporte a `since` para recuperar apenas novidades desde a última consulta.
+
+[Unreleased]: https://github.com/DeHor-Labs/mcp-juridico-brasil/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/DeHor-Labs/mcp-juridico-brasil/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contribuindo com o mcp-juridico-brasil
+
+Obrigado pelo interesse em contribuir! Este guia descreve como o projeto está organizado,
+o fluxo de desenvolvimento com `uv` e as convenções que seguimos.
+
+## Estrutura dos módulos
+
+Cada domínio jurídico é um pacote Python independente dentro de `src/mcp_juridico_brasil/`:
+
+```
+src/mcp_juridico_brasil/
+├── processual/          # consulta e histórico de processos via DataJud
+│   ├── client.py        # cliente HTTP (httpx + tenacity) para a API DataJud CNJ
+│   ├── schemas.py       # modelos Pydantic de request/response
+│   └── tools.py         # funções MCP expostas via @mcp.tool()
+├── monitoramento/       # resources de acompanhamento e alertas
+│   ├── client.py
+│   ├── schemas.py
+│   └── tools.py
+├── prazo/               # cálculo de prazo processual com calendário de feriados
+│   ├── client.py
+│   ├── schemas.py
+│   └── tools.py
+├── jurisprudencia/      # busca de jurisprudência nos tribunais
+│   ├── client.py
+│   ├── schemas.py
+│   └── tools.py
+├── legislacao/          # textos consolidados de legislação
+│   ├── client.py
+│   ├── schemas.py
+│   └── tools.py
+├── calculos/            # utilitários de cálculo (correção monetária, custas, etc.)
+│   ├── client.py
+│   ├── schemas.py
+│   └── tools.py
+└── core/                # configuração, logging, rate-limit, exceções
+    └── ...
+```
+
+### Convenção dos três arquivos
+
+| Arquivo | Responsabilidade |
+|---------|-----------------|
+| `client.py` | Comunicação com a API DataJud ou outra fonte externa. Usa `httpx.AsyncClient`, `tenacity` para retry e `aiolimiter` para rate-limit. |
+| `schemas.py` | Modelos Pydantic que representam os dados recebidos e retornados. Inclui validators e exemplos de `model_config`. |
+| `tools.py` | Funções decoradas com `@mcp.tool()` que compõem a interface pública do servidor. Cada função deve ter docstring clara e tipos anotados. |
+
+## Fonte de dados principal: DataJud CNJ
+
+A API DataJud do Conselho Nacional de Justiça fornece acesso a dados processuais de
+91 tribunais brasileiros (STF, STJ, TJs, TRFs, TRTs, etc.). Toda consulta processual
+deve passar pelo cliente em `processual/client.py` ou pelo módulo correspondente.
+
+Documentação oficial: https://datajud-wiki.cnj.jus.br/
+
+## Ambiente de desenvolvimento
+
+Este projeto usa [`uv`](https://docs.astral.sh/uv/) como gerenciador de pacotes e
+ambiente virtual.
+
+### Configuração inicial
+
+```bash
+# Clone o repositório
+git clone https://github.com/DeHor-Labs/mcp-juridico-brasil.git
+cd mcp-juridico-brasil
+
+# Instala dependências (cria .venv automaticamente)
+uv sync
+
+# Ativa o ambiente (uv run faz isso automaticamente em cada comando)
+source .venv/bin/activate
+```
+
+### Executar testes
+
+```bash
+uv run pytest tests/ -v
+uv run pytest tests/ --cov=src --cov-report=term-missing
+```
+
+### Lint e formatação
+
+```bash
+uv run ruff check src tests
+uv run ruff format --check src tests
+
+# Corrigir automaticamente
+uv run ruff check --fix src tests
+uv run ruff format src tests
+```
+
+### Verificação de tipos
+
+```bash
+uv run mypy src
+```
+
+### Atalho via Makefile
+
+```bash
+make check          # lint + typecheck
+make test           # testes
+make build          # empacota o wheel
+```
+
+## Fluxo de contribuição
+
+1. **Abra uma issue** descrevendo o bug ou a funcionalidade antes de abrir um PR.
+2. **Crie uma branch** a partir de `main`:
+   ```bash
+   git checkout -b feat/nome-da-feature
+   ```
+3. **Implemente** seguindo a convenção `client.py + schemas.py + tools.py`.
+4. **Adicione testes** em `tests/` cobrindo os novos comportamentos.
+5. **Rode** `make check` e `make test` e garanta que tudo passa.
+6. **Abra o PR** com título descritivo e preencha o template.
+
+## Convenções de commit
+
+Seguimos [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: consulta por número CNJ no módulo processual
+fix: tratamento de timeout na API DataJud
+docs: exemplos de uso no README
+test: cobertura do cálculo de prazo em recesso
+```
+
+## Código de conduta
+
+Este projeto adota o [Contributor Covenant](https://www.contributor-covenant.org/).
+Seja respeitoso e construtivo nas interações.
+
+## Dúvidas
+
+Abra uma [Discussion](https://github.com/DeHor-Labs/mcp-juridico-brasil/discussions)
+ou envie um e-mail para nikolasdehor79@gmail.com.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# Imagem Docker do mcp-juridico-brasil
+# Multi-stage para imagem final enxuta com uv.
+#
+# Build:
+#   docker build -t mcp-juridico-brasil:0.1.0 .
+#
+# Run (servidor MCP stdio):
+#   docker run --rm -i mcp-juridico-brasil:0.1.0
+#
+# Run (MCP HTTP transport):
+#   docker run --rm -p 8000:8000 mcp-juridico-brasil:0.1.0 mcp-juridico-brasil --transport http
+#
+# Variáveis de ambiente úteis:
+#   DATAJUD_API_KEY=sua_chave
+#   MCP_JURIDICO_HTTP_TIMEOUT=30
+#   MCP_JURIDICO_CACHE_TTL=300
+#   MCP_JURIDICO_RATE_LIMIT=10
+#   HOST=0.0.0.0 PORT=8000
+
+# ---- Build stage ----
+FROM python:3.12-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /build
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src/ ./src/
+
+RUN pip install --no-cache-dir hatchling build && \
+    python -m build --wheel
+
+# ---- Runtime stage ----
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8000 \
+    HOST=0.0.0.0
+
+WORKDIR /app
+
+COPY --from=builder /build/dist/*.whl ./
+
+RUN pip install --no-cache-dir *.whl && \
+    rm -f *.whl && \
+    groupadd -r app && useradd -r -g app -d /app -s /usr/sbin/nologin app && \
+    chown -R app:app /app
+
+USER app
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import mcp_juridico_brasil; print('ok')" || exit 1
+
+# Comando padrão: servidor MCP via stdio (uso por clientes MCP nativos).
+CMD ["mcp-juridico-brasil"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev lint test typecheck clean
+.PHONY: install dev lint test typecheck check build check-release-metadata clean
 
 install:
 	uv sync
@@ -16,6 +16,17 @@ lint-fix:
 
 typecheck:
 	uv run mypy src
+
+# Lint + typecheck (atalho pre-PR)
+check: lint typecheck
+
+# Empacota o wheel (uv build)
+build:
+	uv build
+
+# Valida consistencia de versao entre pyproject.toml, server.json e CHANGELOG.md
+check-release-metadata:
+	@uv run python scripts/check_release_metadata.py
 
 test:
 	uv run pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -1,65 +1,115 @@
-# MCP Juridico Brasil
+<!-- mcp-name: io.github.DeHor-Labs/mcp-juridico-brasil -->
 
-Plataforma de dados juridicos brasileiros exposta via Model Context Protocol (MCP),
-organizada em **modulos por dominio**. O primeiro modulo entregue e o de
-**acompanhamento processual** - consulta, monitoramento e alertas de prazo em
-91 tribunais via [DataJud CNJ](https://datajud-wiki.cnj.jus.br/api-publica/).
+<p align="center">
+  <img src="https://raw.githubusercontent.com/DeHor-Labs/mcp-juridico-brasil/main/assets/banner.svg" width="800" alt="MCP Juridico Brasil">
+</p>
 
-Os proximos modulos (Jurisprudencia, Legislacao, Diarios Oficiais, Calculos Juridicos)
-entram no roadmap apos a conclusao do modulo Processual, cada um como pacote plugavel
-independente. Ver [docs/PLANO-E2E.md](docs/PLANO-E2E.md) para a visao completa.
+<p align="center">
+  <strong>Conecte qualquer assistente de IA ao DataJud CNJ e aos 91 tribunais brasileiros - com cálculo de prazos, monitoramento de processos e conformidade com o CPC.</strong>
+</p>
 
-**Autor:** Nikolas de Hor - nikolasdehor79@gmail.com
-**Status:** Pre-alpha (Fase 0 - scaffold do modulo Processual)
-**Licenca:** MIT
+<p align="center">
+  <a href="https://pypi.org/project/mcp-juridico-brasil/"><img src="https://img.shields.io/pypi/v/mcp-juridico-brasil?color=003087&label=PyPI" alt="PyPI version"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-1a7a4a?logo=python&logoColor=white" alt="Python 3.10+"></a>
+  <a href="https://github.com/DeHor-Labs/mcp-juridico-brasil/actions/workflows/ci.yml"><img src="https://github.com/DeHor-Labs/mcp-juridico-brasil/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/licenca-MIT-4fc3f7?labelColor=001f5b" alt="Licença MIT"></a>
+  <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-compatível-7c3aed" alt="MCP Compatível"></a>
+  <img src="https://img.shields.io/github/stars/DeHor-Labs/mcp-juridico-brasil?style=flat&color=003087" alt="Stars">
+  <img src="https://img.shields.io/github/issues/DeHor-Labs/mcp-juridico-brasil?color=4fc3f7&labelColor=001f5b" alt="Issues">
+</p>
 
-> **AVISO LEGAL:** Este software e destinado exclusivamente ao uso por advogados e
-> profissionais do direito para acompanhamento de processos de seus clientes.
-> Nao constitui consultoria juridica. A analise final e a orientacao ao cliente
-> sao de responsabilidade exclusiva do advogado habilitado (OAB Rec. 001/2024).
+<p align="center">
+  <a href="#o-que-é">O que é</a> ·
+  <a href="#ferramentas-disponíveis">Ferramentas</a> ·
+  <a href="#instalação">Instalação</a> ·
+  <a href="#configuração-por-cliente-mcp">Configuração</a> ·
+  <a href="#roadmap">Roadmap</a> ·
+  <a href="#contribuindo">Contribuindo</a>
+</p>
 
 ---
 
-## O que faz (modulo Processual - MVP)
+## O que é
 
-| Tool | Descricao |
-|---|---|
-| `buscar_processo_por_numero` | Consulta completa de processo pelo numero CNJ em 91 tribunais |
-| `listar_movimentacoes` | Historico de andamentos com codigo TPU e data |
-| `resumir_andamento` | Retorna dados + instrucao para o LLM gerar resumo em linguagem natural |
-| `monitorar_processo` | Verifica se houve atualizacao desde uma data (polling DataJud) |
-| `calcular_proximo_prazo` | Estimativa de prazo processual a partir da ultima movimentacao |
-| `listar_tribunais` | Lista as 91 siglas de tribunais suportados |
+`mcp-juridico-brasil` conecta assistentes de IA, escritórios de advocacia e sistemas de gestão processual ao **DataJud CNJ** - a base unificada de dados judiciais do Conselho Nacional de Justiça - com cobertura de **91 tribunais brasileiros** em todas as justiças (Federal, Estadual, do Trabalho, Militar, Eleitoral e Superior).
 
-## Cobertura
+O servidor não é um catálogo genérico de dados públicos. A proposta é ser uma vertical processual: transformar consultas judiciais fragmentadas em **tools seguras, componíveis e prontas para agentes** - com cálculo de prazos em dias úteis conforme o CPC, monitoramento de andamentos e snapshots persistentes de processos.
 
-91 tribunais via API publica DataJud (CNJ):
-- Tribunais superiores: STF, STJ, TST, TSE, STM
-- Tribunais Regionais Federais: TRF1 a TRF6
-- Tribunais Regionais do Trabalho: TRT1 a TRT24
-- Tribunais de Justica estaduais e DF (27)
-- Tribunais Regionais Eleitorais e Militares Estaduais
+---
 
-**Limitacao importante:** O DataJud tem defasagem de T+1 a T+7 dias dependendo do tribunal. Para monitoramento de prazos criticos em producao, configure um provider comercial (Judit, Escavador) na Fase 3.
+## Ferramentas disponíveis
 
-## Instalacao
+Tools de Fase 1 e Fase 2, prontas para uso imediato.
 
-### Via uvx (recomendado)
+### Consulta e monitoramento de processos
+
+| Ferramenta | Descrição | Fonte |
+|------------|-----------|-------|
+| `buscar_processo_por_numero` | Consulta completa de processo pelo número CNJ (NNNNNNN-DD.AAAA.J.TT.OOOO) | DataJud CNJ |
+| `listar_movimentacoes` | Histórico de andamentos processuais com filtro por data | DataJud CNJ |
+| `resumir_andamento` | Dados do processo mais instrução de resumo para o modelo de linguagem | DataJud CNJ |
+| `monitorar_processo` | Verifica atualizações desde uma data (polling com snapshot em memória) | DataJud CNJ |
+| `listar_processos_monitorados` | Lista processos com snapshot salvo na sessão atual | Memória local |
+
+### Cálculo de prazos processuais
+
+| Ferramenta | Descrição | Referência |
+|------------|-----------|------------|
+| `calcular_proximo_prazo` | Cálculo de prazo em dias úteis com calendário forense nacional e estadual (art. 219, 220 e 224 CPC) | Offline |
+
+### Referência de tribunais
+
+| Ferramenta | Descrição | Fonte |
+|------------|-----------|-------|
+| `listar_tribunais` | Lista todas as 91 siglas suportadas (Portaria CNJ 160/2020) | Offline |
+
+### Resource MCP
+
+| Resource | Descrição |
+|----------|-----------|
+| `processo://{numero}/snapshot` | Último snapshot capturado de um processo monitorado |
+
+---
+
+## Instalação
+
+A forma mais simples, sem instalar nada permanentemente:
 
 ```bash
 uvx mcp-juridico-brasil
 ```
 
-### Via pip
+> **O que é `uvx`?** É o gerenciador de ferramentas do [uv](https://docs.astral.sh/uv/), que baixa e executa pacotes Python em ambiente isolado, sem poluir seu sistema. Se ainda não tem o uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+> **Mantendo atualizado:** use `uvx mcp-juridico-brasil@latest` ou `uvx --refresh mcp-juridico-brasil` para forçar a versão mais recente do PyPI.
+
+### Instalação permanente (alternativa)
 
 ```bash
+# via pip
 pip install mcp-juridico-brasil
-mcp-juridico-brasil
+
+# via uv (recomendado para projetos Python)
+uv add mcp-juridico-brasil
 ```
 
-### Configuracao no Claude Desktop
+### A partir do código-fonte
 
-Adicione ao `claude_desktop_config.json`:
+```bash
+git clone https://github.com/DeHor-Labs/mcp-juridico-brasil.git
+cd mcp-juridico-brasil
+uv sync
+```
+
+---
+
+## Configuração por cliente MCP
+
+Cole o trecho abaixo no arquivo de configuração do seu cliente. A variável `DATAJUD_API_KEY` é necessária para consultas ao DataJud CNJ - solicite em [datajud-wiki.cnj.jus.br](https://datajud-wiki.cnj.jus.br/api-publica/acesso/).
+
+### Claude Desktop
+
+Edite `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) ou `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
 ```json
 {
@@ -75,58 +125,160 @@ Adicione ao `claude_desktop_config.json`:
 }
 ```
 
-A chave publica padrao ja esta embutida no codigo. Atualize se o CNJ rotacionar.
-Consulte sempre: https://datajud-wiki.cnj.jus.br/api-publica/acesso/
+Reinicie o Claude Desktop. As ferramentas jurídicas aparecem automaticamente.
 
-## Desenvolvimento local
-
-Requer Python 3.10+ e [uv](https://github.com/astral-sh/uv).
+### Claude Code (CLI)
 
 ```bash
-git clone https://github.com/DeHor-Labs/mcp-juridico-brasil
-cd mcp-juridico-brasil
-uv sync --extra dev
-cp .env.example .env
-make test
+claude mcp add juridico-brasil -- uvx mcp-juridico-brasil
 ```
+
+Para incluir a chave de API:
+
+```bash
+DATAJUD_API_KEY=sua-chave-aqui claude mcp add juridico-brasil -- uvx mcp-juridico-brasil
+```
+
+### Cursor / `.mcp.json`
+
+Crie ou edite `.cursor/mcp.json` (ou `.mcp.json` na raiz do projeto):
+
+```json
+{
+  "mcpServers": {
+    "juridico-brasil": {
+      "command": "uvx",
+      "args": ["mcp-juridico-brasil"],
+      "env": {
+        "DATAJUD_API_KEY": "sua-chave-aqui"
+      }
+    }
+  }
+}
+```
+
+### VS Code + Continue
+
+Adicione ao `settings.json`:
+
+```json
+{
+  "continue.mcpServers": {
+    "juridico-brasil": {
+      "command": "uvx",
+      "args": ["mcp-juridico-brasil"],
+      "env": {
+        "DATAJUD_API_KEY": "sua-chave-aqui"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Variáveis de ambiente
+
+| Variável | Descrição | Padrão |
+|----------|-----------|--------|
+| `DATAJUD_API_KEY` | Chave de acesso ao DataJud CNJ (necessária para consultas) | - |
+| `MCP_JURIDICO_LOG_LEVEL` | Nível de log: `DEBUG`, `INFO`, `WARNING` | `INFO` |
+| `JURIDICO_SNAPSHOT_DIR` | Diretório para persistência de snapshots em arquivo (opcional) | memória |
+| `HTTP_TIMEOUT` | Timeout em segundos para chamadas HTTP ao DataJud | `30` |
+
+---
+
+## Arquitetura
+
+```
+Claude / GPT / Cursor / qualquer cliente MCP
+              |
+              | Model Context Protocol (stdio)
+              v
+    mcp-juridico-brasil
+              |
+    +---------+---------+-----------+----------+
+    |         |         |           |          |
+ Processos  Movim.   Resumo    Monitoram.  Prazos
+    |         |         |           |          |
+    v         v         v           v          v
+ DataJud   DataJud   DataJud   Snapshot   Calendario
+  CNJ        CNJ       CNJ     mem/disco   forense
+                                           offline
+              |
+              v
+       91 tribunais
+  (Federal, Estadual, Trabalho,
+   Militar, Eleitoral, Superior)
+```
+
+**Fontes de dados:**
+- [DataJud CNJ](https://datajud-wiki.cnj.jus.br/) - base unificada de dados judiciais (Portaria CNJ 160/2020)
+- Calendário forense nacional e estadual - processado offline para cálculo de prazos (CPC art. 219/220/224)
+
+---
 
 ## Roadmap
 
-### Modulo Processual (Fases 0-4)
+- [x] **v0.1.x** - Busca de processo, listagem de movimentações, resumo de andamento e listagem de tribunais
+- [x] **v0.2.x** - Monitoramento com snapshot, cálculo de prazos em dias úteis (CPC), resource MCP por processo
+- [ ] **v0.3.x** - Webhook push de atualizações, persistência em banco de dados e alertas por prazo
+- [ ] **v0.4.x** - Intimações via Domicílio Judicial Eletrônico (DJe), parsing de publicações e extração estruturada
+- [ ] **v1.0.0** - Suite processual completa com auditoria LGPD, contratos de API estáveis e cobertura ampliada
 
-| Fase | Status | Descricao |
-|---|---|---|
-| Fase 0 | Em andamento | Scaffold, estrutura, CI |
-| Fase 1 | Planejado | MVP DataJud - todas as tools funcionais |
-| Fase 2 | Planejado | Monitoramento, alertas, calendario forense |
-| Fase 3 | Planejado | Provider comercial com webhook push |
-| Fase 4 | Planejado | Intimacoes DJe (Domicilio Judicial Eletronico) |
-
-### Modulos futuros (pos-Fase 4)
-
-| Modulo | Fontes candidatas |
-|---|---|
-| Jurisprudencia | STF, STJ, TST, TJs (portais e APIs) |
-| Diarios Oficiais | DJEN/CNJ, Querido Diario (Open Knowledge Brasil) |
-| Legislacao | LexML, portal Planalto, DOU |
-| Calculos Juridicos | Tabelas CNJ, IPCA/SELIC Banco Central |
-
-Cada modulo futuro entra com seu proprio plano, versionamento e fontes validadas.
-
-Ver [docs/PLANO-E2E.md](docs/PLANO-E2E.md) para o plano completo, incluindo a visao de plataforma modular.
+---
 
 ## Privacidade e LGPD
 
-- Processos em segredo de justica sao **bloqueados** com erro explicito (nao ha fallback nem tentativa de contornar o sigilo)
-- Nenhum CPF/CNPJ de partes e persistido internamente
-- Dados sensiveis (saude, origem etnica, orientacao sexual) nao sao indexados
-- Politica de retencao: somente enquanto necessario ao proposito declarado
-- Fundamento: LGPD (Lei 13.709/2018) e Resolucao CNJ 647/2025
+> **Atenção:** o `mcp-juridico-brasil` acessa exclusivamente dados públicos disponibilizados pelo DataJud CNJ (Resolução CNJ 331/2020). Processos em **segredo de justiça** não são retornados pela API e não são acessados por este servidor. Nenhum dado processual é armazenado fora do ambiente local do usuário - exceto quando `JURIDICO_SNAPSHOT_DIR` é configurado explicitamente. O uso das ferramentas é de responsabilidade do profissional habilitado, em conformidade com a LGPD (Lei 13.709/2018), a Resolução CNJ 647/2025 e a OAB Recomendação 001/2024. Estas ferramentas não constituem consultoria jurídica.
 
-## Irmao deste projeto
+---
 
-[MCP Fiscal Brasil](https://github.com/DeHor-Labs/mcp-fiscal-brasil) - 41 ferramentas fiscais brasileiras (CNPJ, NF-e, IBS/CBS, Simples Nacional).
+## Contribuindo
 
-## Contribuicao
+Contribuições são bem-vindas!
 
-Issues e PRs sao bem-vindos. Ver [CONTRIBUTING.md](CONTRIBUTING.md) (a criar na Fase 1).
+```bash
+# 1. Clone o repositório ou seu fork
+git clone https://github.com/DeHor-Labs/mcp-juridico-brasil.git
+cd mcp-juridico-brasil
+
+# 2. Instale as dependências de desenvolvimento
+uv sync
+
+# 3. Crie sua branch
+git checkout -b feature/meu-recurso
+
+# 4. Implemente, teste e verifique
+pytest
+ruff check src/
+mypy src/
+
+# 5. Abra um Pull Request
+```
+
+Veja as [issues abertas](https://github.com/DeHor-Labs/mcp-juridico-brasil/issues) - especialmente as marcadas com `good first issue`.
+
+Cada módulo segue o padrão `client.py` + `schemas.py` + `tools.py`, tornando simples adicionar novos módulos processuais.
+
+---
+
+## Projeto irmão
+
+Este servidor faz par com o **MCP Fiscal Brasil**, que conecta IAs ao sistema fiscal brasileiro (NF-e, SPED, CNPJ, Simples Nacional, Reforma Tributária 2026):
+
+[github.com/DeHor-Labs/mcp-fiscal-brasil](https://github.com/DeHor-Labs/mcp-fiscal-brasil)
+
+---
+
+## Licença
+
+MIT - veja [LICENSE](LICENSE) para detalhes.
+
+---
+
+<p align="center">
+  Feito com dedicação para o Judiciário brasileiro
+  <br>
+  <sub>Conectando inteligência artificial aos 91 tribunais do sistema de justiça nacional</sub>
+</p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Política de Segurança
+
+## Reportar uma Vulnerabilidade
+
+Se você descobrir uma vulnerabilidade de segurança, reporte de forma responsável
+enviando um e-mail para nikolasdehor79@gmail.com.
+
+Não abra uma issue pública para vulnerabilidades de segurança.

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,0 +1,113 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
+  <defs>
+    <!-- Gradiente azul royal para azul escuro judicial -->
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#001f5b;stop-opacity:1"/>
+      <stop offset="40%" style="stop-color:#003087;stop-opacity:1"/>
+      <stop offset="70%" style="stop-color:#0a4a2a;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#1a7a4a;stop-opacity:1"/>
+    </linearGradient>
+    <!-- Brilho verde ao redor do logo -->
+    <radialGradient id="greenGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" style="stop-color:#1a7a4a;stop-opacity:0.3"/>
+      <stop offset="100%" style="stop-color:#1a7a4a;stop-opacity:0"/>
+    </radialGradient>
+    <!-- Grade sutil -->
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse" opacity="0.05">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="white" stroke-width="0.5"/>
+    </pattern>
+  </defs>
+
+  <!-- Fundo -->
+  <rect width="800" height="200" fill="url(#bgGrad)"/>
+  <rect width="800" height="200" fill="url(#grid)"/>
+
+  <!-- Brilho atras do logo -->
+  <circle cx="100" cy="100" r="80" fill="url(#greenGlow)"/>
+
+  <!-- Logo: circulos concentricos -->
+  <circle cx="100" cy="100" r="68" fill="#003087"/>
+  <circle cx="100" cy="100" r="55" fill="#1a7a4a"/>
+  <circle cx="100" cy="100" r="40" fill="#001f5b"/>
+
+  <!-- Balanca da justica: haste central -->
+  <rect x="98.5" y="72" width="3" height="38" rx="1.5" fill="white" opacity="0.95"/>
+
+  <!-- Travessao horizontal da balanca -->
+  <rect x="82" y="73" width="36" height="3.5" rx="1.75" fill="white" opacity="0.95"/>
+
+  <!-- Prato esquerdo: fio -->
+  <line x1="87" y1="76.5" x2="87" y2="87" stroke="white" stroke-width="2" stroke-linecap="round" opacity="0.9"/>
+  <!-- Prato esquerdo: arco -->
+  <path d="M80 87 Q87 91 94 87" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" opacity="0.9"/>
+
+  <!-- Prato direito: fio (levemente mais baixo) -->
+  <line x1="113" y1="76.5" x2="113" y2="92" stroke="white" stroke-width="2" stroke-linecap="round" opacity="0.9"/>
+  <!-- Prato direito: arco -->
+  <path d="M106 92 Q113 96 120 92" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" opacity="0.9"/>
+
+  <!-- Base da balanca -->
+  <rect x="95" y="110" width="10" height="3" rx="1.5" fill="white" opacity="0.8"/>
+  <rect x="90" y="113" width="20" height="3" rx="1.5" fill="white" opacity="0.7"/>
+
+  <!-- Nos de IA na base -->
+  <circle cx="87" cy="104" r="3.5" fill="#4fc3f7"/>
+  <circle cx="100" cy="104" r="3.5" fill="#4fc3f7"/>
+  <circle cx="113" cy="104" r="3.5" fill="#4fc3f7"/>
+  <line x1="90.5" y1="104" x2="96.5" y2="104" stroke="#4fc3f7" stroke-width="1.5"/>
+  <line x1="103.5" y1="104" x2="109.5" y2="104" stroke="#4fc3f7" stroke-width="1.5"/>
+
+  <!-- Separador decorativo -->
+  <line x1="180" y1="40" x2="180" y2="160" stroke="#4fc3f7" stroke-width="1" opacity="0.3"/>
+
+  <!-- Titulo principal -->
+  <text x="210" y="88" font-family="'Segoe UI', system-ui, -apple-system, sans-serif" font-size="42" font-weight="700" fill="white" letter-spacing="-1">MCP Juridico Brasil</text>
+
+  <!-- Barra de acento azul claro sob o titulo -->
+  <rect x="210" y="98" width="330" height="3" rx="1.5" fill="#4fc3f7" opacity="0.8"/>
+
+  <!-- Tagline -->
+  <text x="212" y="132" font-family="'Segoe UI', system-ui, -apple-system, sans-serif" font-size="17" fill="white" opacity="0.85" letter-spacing="0.3">Conectando IAs ao sistema judiciario brasileiro</text>
+
+  <!-- Badges de tecnologia -->
+  <!-- MCP -->
+  <rect x="212" y="148" width="60" height="22" rx="11" fill="#4fc3f7" opacity="0.15"/>
+  <text x="242" y="163" font-family="'Segoe UI', system-ui, sans-serif" font-size="11" fill="#4fc3f7" text-anchor="middle" font-weight="600">MCP</text>
+
+  <!-- Python -->
+  <rect x="280" y="148" width="72" height="22" rx="11" fill="#4fc3f7" opacity="0.15"/>
+  <text x="316" y="163" font-family="'Segoe UI', system-ui, sans-serif" font-size="11" fill="#4fc3f7" text-anchor="middle" font-weight="600">Python 3.10+</text>
+
+  <!-- DataJud -->
+  <rect x="360" y="148" width="62" height="22" rx="11" fill="#4fc3f7" opacity="0.15"/>
+  <text x="391" y="163" font-family="'Segoe UI', system-ui, sans-serif" font-size="11" fill="#4fc3f7" text-anchor="middle" font-weight="600">DataJud</text>
+
+  <!-- 91 Tribunais -->
+  <rect x="430" y="148" width="84" height="22" rx="11" fill="#4fc3f7" opacity="0.15"/>
+  <text x="472" y="163" font-family="'Segoe UI', system-ui, sans-serif" font-size="11" fill="#4fc3f7" text-anchor="middle" font-weight="600">91 Tribunais</text>
+
+  <!-- Pontos decorativos canto superior direito -->
+  <circle cx="720" cy="40" r="3" fill="#4fc3f7" opacity="0.2"/>
+  <circle cx="740" cy="30" r="2" fill="#4fc3f7" opacity="0.15"/>
+  <circle cx="760" cy="50" r="4" fill="#1a7a4a" opacity="0.3"/>
+  <circle cx="780" cy="35" r="2.5" fill="#4fc3f7" opacity="0.2"/>
+  <circle cx="750" cy="65" r="1.5" fill="white" opacity="0.15"/>
+
+  <!-- Pontos decorativos canto inferior direito -->
+  <circle cx="710" cy="160" r="2" fill="#4fc3f7" opacity="0.15"/>
+  <circle cx="740" cy="170" r="3" fill="#1a7a4a" opacity="0.2"/>
+  <circle cx="770" cy="155" r="2" fill="white" opacity="0.1"/>
+  <circle cx="790" cy="145" r="1.5" fill="#4fc3f7" opacity="0.15"/>
+
+  <!-- Nos conectados decorativos (lado direito) -->
+  <circle cx="660" cy="80" r="5" fill="#4fc3f7" opacity="0.25"/>
+  <circle cx="690" cy="60" r="4" fill="#4fc3f7" opacity="0.2"/>
+  <circle cx="700" cy="100" r="6" fill="#1a7a4a" opacity="0.3"/>
+  <circle cx="670" cy="130" r="4" fill="#4fc3f7" opacity="0.2"/>
+  <circle cx="640" cy="110" r="3" fill="white" opacity="0.15"/>
+  <line x1="660" y1="80" x2="690" y2="60" stroke="#4fc3f7" stroke-width="1" opacity="0.2"/>
+  <line x1="660" y1="80" x2="700" y2="100" stroke="#4fc3f7" stroke-width="1" opacity="0.2"/>
+  <line x1="700" y1="100" x2="670" y2="130" stroke="#4fc3f7" stroke-width="1" opacity="0.2"/>
+  <line x1="670" y1="130" x2="640" y2="110" stroke="#4fc3f7" stroke-width="1" opacity="0.15"/>
+  <line x1="640" y1="110" x2="660" y2="80" stroke="#4fc3f7" stroke-width="1" opacity="0.15"/>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <!-- Circulo externo azul royal -->
+  <circle cx="60" cy="60" r="58" fill="#003087"/>
+  <!-- Circulo medio verde judicial -->
+  <circle cx="60" cy="60" r="46" fill="#1a7a4a"/>
+  <!-- Circulo interno azul escuro -->
+  <circle cx="60" cy="60" r="34" fill="#001f5b"/>
+
+  <!-- Balanca da justica: haste central -->
+  <rect x="58.5" y="38" width="3" height="34" rx="1.5" fill="white" opacity="0.95"/>
+
+  <!-- Topo da balanca (travessao horizontal) -->
+  <rect x="44" y="39" width="32" height="3" rx="1.5" fill="white" opacity="0.95"/>
+
+  <!-- Prato esquerdo: corrente -->
+  <line x1="48" y1="42" x2="48" y2="51" stroke="white" stroke-width="1.8" stroke-linecap="round" opacity="0.9"/>
+  <!-- Prato esquerdo: base -->
+  <path d="M42 51 Q48 54 54 51" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" opacity="0.9"/>
+
+  <!-- Prato direito: corrente -->
+  <line x1="72" y1="42" x2="72" y2="55" stroke="white" stroke-width="1.8" stroke-linecap="round" opacity="0.9"/>
+  <!-- Prato direito: base (levemente mais baixo, dinamismo) -->
+  <path d="M66 55 Q72 58 78 55" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" opacity="0.9"/>
+
+  <!-- Base da balanca -->
+  <rect x="55" y="72" width="10" height="2.5" rx="1.2" fill="white" opacity="0.8"/>
+  <rect x="51" y="74.5" width="18" height="2.5" rx="1.2" fill="white" opacity="0.7"/>
+
+  <!-- Nos de IA na base (conectividade) -->
+  <circle cx="49" cy="66" r="3" fill="#4fc3f7"/>
+  <circle cx="60" cy="66" r="3" fill="#4fc3f7"/>
+  <circle cx="71" cy="66" r="3" fill="#4fc3f7"/>
+  <line x1="52" y1="66" x2="57" y2="66" stroke="#4fc3f7" stroke-width="1.5"/>
+  <line x1="63" y1="66" x2="68" y2="66" stroke="#4fc3f7" stroke-width="1.5"/>
+
+  <!-- Estrelas decorativas -->
+  <circle cx="60" cy="48" r="1.2" fill="white" opacity="0.4"/>
+  <circle cx="52" cy="56" r="1" fill="white" opacity="0.3"/>
+  <circle cx="68" cy="54" r="1" fill="white" opacity="0.3"/>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ mcp-juridico = "mcp_juridico_brasil.cli:main"
 Homepage = "https://github.com/DeHor-Labs/mcp-juridico-brasil"
 Repository = "https://github.com/DeHor-Labs/mcp-juridico-brasil"
 Issues = "https://github.com/DeHor-Labs/mcp-juridico-brasil/issues"
+Changelog = "https://github.com/DeHor-Labs/mcp-juridico-brasil/blob/main/CHANGELOG.md"
+Examples = "https://github.com/DeHor-Labs/mcp-juridico-brasil/tree/main/examples"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcp_juridico_brasil"]

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,0 +1,60 @@
+"""Verifica consistência dos metadados de release entre pyproject.toml, server.json e CHANGELOG.md."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+try:
+    import tomllib  # py311+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+
+def main() -> int:
+    root = pathlib.Path(__file__).resolve().parents[1]
+
+    with (root / "pyproject.toml").open("rb") as fp:
+        project_data = tomllib.load(fp)
+
+    with (root / "server.json").open("r", encoding="utf-8") as fp:
+        server_data = json.load(fp)
+
+    with (root / "CHANGELOG.md").open("r", encoding="utf-8") as fp:
+        changelog = fp.read()
+
+    release_version = project_data["project"]["version"]
+
+    versions: dict[str, str] = {
+        "pyproject.toml": release_version,
+        "server.json": server_data["version"],
+    }
+
+    for idx, package_data in enumerate(server_data.get("packages", [])):
+        package_version = package_data.get("version")
+        package_name = package_data.get("identifier", f"package-{idx}")
+        package_path = f"server.json.packages[{idx}] ({package_name})"
+        if package_version is None:
+            print(f"FALHA: {package_path} nao declara version.")
+            return 1
+        versions[f"{package_path}.version"] = package_version
+
+    unique_versions = set(versions.values())
+
+    if len(unique_versions) != 1:
+        print("FALHA: versoes inconsistentes nos metadados.")
+        for file_path, version in versions.items():
+            print(f"  {file_path}: {version}")
+        return 1
+
+    if f"## [{release_version}]" not in changelog:
+        print(f"FALHA: secao ## [{release_version}] nao encontrada no CHANGELOG.md.")
+        return 1
+
+    print(f"OK: release metadata consistente ({release_version})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mcp_juridico_brasil/prazo/calendario.py
+++ b/src/mcp_juridico_brasil/prazo/calendario.py
@@ -182,9 +182,7 @@ class _CalendarioCache:
         cal_uf = cal_class()
         nacionais = self._feriados_nacionais_base(ano)
         return {
-            d: f"{n} (feriado estadual {uf})"
-            for d, n in cal_uf.holidays(ano)
-            if d not in nacionais
+            d: f"{n} (feriado estadual {uf})" for d, n in cal_uf.holidays(ano) if d not in nacionais
         }
 
     def get_feriados(self, uf: str | None, ano: int) -> set[datetime.date]:


### PR DESCRIPTION
## O que foi alinhado

- **Workflows de publicacao**: `publish.yml` (PyPI via trusted publishing), `publish-mcp-registry.yml` (registro MCP), `welcome.yml` (boas-vindas a novos contribuidores)
- **Dependabot**: `dependabot.yml` (pip + github-actions, semanal) e `dependabot-auto-merge.yml` (auto-merge de patches de dependencias)
- **CI expandido**: matriz Python 3.10/3.11/3.12/3.13, jobs `lint`/`typecheck`/`test` separados, upload de cobertura via Codecov, validacao de metadados de release em cada run
- **README**: banner SVG, badges (PyPI, Python, CI, MIT, MCP, stars, issues), secao multi-cliente (Claude Desktop, Claude Code, Cursor, VS Code + Continue), tabela de variaveis de ambiente, roadmap faseado, link para projeto irmao mcp-fiscal-brasil
- **CONTRIBUTING.md**: estrutura de modulos (`client.py + schemas.py + tools.py`), guia de ambiente com `uv`, convencoes de commit, codigo de conduta
- **SECURITY.md**: politica de divulgacao responsavel de vulnerabilidades
- **Templates de issue e PR**: `bug_report.yml`, `feature_request.yml`, `PULL_REQUEST_TEMPLATE.md`
- **Dockerfile**: imagem minimalista `python:3.12-slim` para execucao containerizada
- **CHANGELOG.md**: historico das Fases 1 e 2 em formato Keep a Changelog
- **scripts/check_release_metadata.py**: validacao de metadados do `pyproject.toml` antes de cada release
- **pyproject.toml**: extras `[dev]` alinhados com o que o CI instala

## O que NAO foi copiado

Nenhum conteudo de dominio fiscal: sem tools de NF-e, CNPJ, SPED, BrasilAPI, SEFAZ ou taglines fiscais. Apenas a estrutura e os padroes foram adaptados para o dominio juridico (DataJud, processos, 91 tribunais).

## Plano de teste

- [ ] CI verde nas 4 versoes de Python (3.10, 3.11, 3.12, 3.13)
- [ ] Job de lint e typecheck passando
- [ ] `uv run pytest -q` local: 93 testes, sem falhas
- [ ] `uv run ruff check .` local: sem erros