### PR TITLE
docs: corrige acentuação pt-BR em docs e docstrings

### DIFF
--- a/docs/PESQUISA.md
+++ b/docs/PESQUISA.md
@@ -1,195 +1,195 @@
-# Pesquisa de Base - MCP Juridico Brasil
+# Pesquisa de Base - MCP Jurídico Brasil
 
 **Autor:** Nikolas de Hor - nikolasdehor79@gmail.com
 **Data:** junho de 2026
 
-Consolidacao da pesquisa tecnica, legal e de mercado que embasou o design
-do projeto. Serve como referencia para decisoes de arquitetura e como
+Consolidação da pesquisa técnica, legal e de mercado que embasou o design
+do projeto. Serve como referência para decisões de arquitetura e como
 material de onboarding para contribuidores.
 
 ---
 
 ## 1. Fontes Oficiais de Dados Processuais
 
-### 1.1 API Publica DataJud (CNJ) - FONTE PRIMARIA DO MVP
+### 1.1 API Pública DataJud (CNJ) - FONTE PRIMÁRIA DO MVP
 
 URL base: `https://api-publica.datajud.cnj.jus.br/api_publica_{sigla_tribunal}/_search`
 
-Autenticacao: APIKey publica (sem cadastro). Chave atual publicada em:
+Autenticação: APIKey pública (sem cadastro). Chave atual publicada em:
 https://datajud-wiki.cnj.jus.br/api-publica/acesso/
 
 Fundamento legal: Portaria CNJ 160/2020.
 
 **O que retorna:**
-- Metadados do processo: numero CNJ, tribunal, grau, datas, nivel de sigilo
+- Metadados do processo: número CNJ, tribunal, grau, datas, nível de sigilo
 - Classe e assunto (tabela TPU unificada CNJ)
-- Orgao julgador com codigo IBGE do municipio
-- Partes (nome e tipo - CPF/CNPJ nao indexado por LGPD)
-- Movimentacoes com codigo TPU, nome e data/hora
-- Formato (fisico/eletronico) e sistema (PJe, eSAJ, eProc, etc.)
+- Órgão julgador com código IBGE do município
+- Partes (nome e tipo - CPF/CNPJ não indexado por LGPD)
+- Movimentações com código TPU, nome e data/hora
+- Formato (físico/eletrônico) e sistema (PJe, eSAJ, eProc, etc.)
 
-**O que NAO retorna:**
-- Teor das pecas (peticoes, decisoes, acordaos integrais)
+**O que NÃO retorna:**
+- Teor das peças (petições, decisões, acórdãos integrais)
 - Processos sigilosos (nivelSigilo > 0)
 - Busca direta por CPF/CNPJ
 - Webhooks (somente polling)
 
 **Cobertura:** 91 tribunais (superiores, TRFs, TRTs, TJs estaduais, TREs, militares)
 
-**Defasagem:** T+1 a T+7 dias por tribunal. Inadequado para prazos criticos
-sem estrategia de redundancia.
+**Defasagem:** T+1 a T+7 dias por tribunal. Inadequado para prazos críticos
+sem estratégia de redundância.
 
-**Limite de taxa:** Nao publicado abertamente. Para uso em escala, solicitar
+**Limite de taxa:** Não publicado abertamente. Para uso em escala, solicitar
 aumento de cota diretamente ao CNJ.
 
-### 1.2 API Comunica - Domicilio Judicial Eletronico (Fase 4)
+### 1.2 API Comunica - Domicílio Judicial Eletrônico (Fase 4)
 
 Portal: https://domicilio-eletronico.pdpj.jus.br
 
-Fundamento: Resolucao CNJ 455/2022 (art. IV). Obrigatorio para PJ desde
-30/05/2024, para orgaos publicos desde 30/09/2024, para PF desde 01/10/2024.
+Fundamento: Resolução CNJ 455/2022 (art. IV). Obrigatório para PJ desde
+30/05/2024, para órgãos públicos desde 30/09/2024, para PF desde 01/10/2024.
 
-Autenticacao: OAuth2 `client_credentials` via GeCli. Header obrigatorio:
-`On-behalf-Of: [CPF sem pontuacao]` para auditoria.
+Autenticação: OAuth2 `client_credentials` via GeCli. Header obrigatório:
+`On-behalf-Of: [CPF sem pontuação]` para auditoria.
 
 Endpoints principais:
 - `GET /api/v1/eu` - recupera tenant ID
-- `GET /comunicacoes` - lista comunicacoes (filtro: ate 7 dias ou por processo)
+- `GET /comunicacoes` - lista comunicações (filtro: até 7 dias ou por processo)
 - `PUT /processos/{numero}/comunicacoes/{id}` - marca como lida (INICIA PRAZO)
 - `GET /processos/{numero}/logs` - logs de eventos
 
-**CRITICO:** Marcar como lida via API tem efeito juridico real. Implementar
-confirmacao explicita antes de executar (Fase 4).
+**CRÍTICO:** Marcar como lida via API tem efeito jurídico real. Implementar
+confirmação explícita antes de executar (Fase 4).
 
-Status de migracao: prazo de migracao de autenticacao era 31/03/2026.
-Verificar versao atual da API antes de implementar Fase 4.
+Status de migração: prazo de migração de autenticação era 31/03/2026.
+Verificar versão atual da API antes de implementar Fase 4.
 
-### 1.3 PJe/MNI, e-SAJ, Projudi - Avaliacao
+### 1.3 PJe/MNI, e-SAJ, Projudi - Avaliação
 
 | Sistema | Viabilidade para MCP | Motivo |
 |---|---|---|
 | PJe MNI (SOAP) | Baixa | Fragmentado por tribunal, sem credencial nacional |
-| e-SAJ TJSP | Muito baixa | Sem API publica, reCAPTCHA, ToS proibe automacao |
+| e-SAJ TJSP | Muito baixa | Sem API pública, reCAPTCHA, ToS proíbe automação |
 | Projudi TJPR | Baixa | SOAP, cobre apenas TJPR |
-| Scraping geral | Descartado | Fragil, viola ToS da maioria dos portais |
+| Scraping geral | Descartado | Frágil, viola ToS da maioria dos portais |
 
-**Conclusao:** DataJud e a unica fonte oficial, gratuita e REST com cobertura
-nacional. Para producao em escala, combinar com provider comercial (Fase 3).
+**Conclusão:** DataJud é a única fonte oficial, gratuita e REST com cobertura
+nacional. Para produção em escala, combinar com provider comercial (Fase 3).
 
 ---
 
-## 2. APIs Comerciais - Avaliacao Comparativa
+## 2. APIs Comerciais - Avaliação Comparativa
 
 ### 2.1 Para o MVP e desenvolvimento
 
-**TrackJud** (trackjud.com.br) - Melhor para MVP/prototipo:
+**TrackJud** (trackjud.com.br) - Melhor para MVP/protótipo:
 - R$ 0,10 por consulta/tribunal, sem mensalidade, sem contrato
-- Acesso imediato, documentacao OpenAPI 3.1
+- Acesso imediato, documentação OpenAPI 3.1
 - Cobertura limitada (10 estados - SP, RJ, PE, AM, DF entre outros)
 - Sem webhook documentado
-- Ideal para testar integracao de provider comercial na Fase 3
+- Ideal para testar integração de provider comercial na Fase 3
 
-### 2.2 Para producao (Fase 3)
+### 2.2 Para produção (Fase 3)
 
-**Judit.io** (judit.io) - Melhor custo-beneficio para B2B:
-- 100% dos tribunais declarado, base propria +450 mi processos
+**Judit.io** (judit.io) - Melhor custo-benefício para B2B:
+- 100% dos tribunais declarado, base própria +450 mi processos
 - Webhook nativo, SLA contratual nos planos anuais
-- R$ 1.000/mes (plano entrada) a R$ 35.000/mes
+- R$ 1.000/mês (plano entrada) a R$ 35.000/mês
 - R$ 0,07 a R$ 0,25 por consulta conforme volume
 - Reconhecimento Febraban, SPC Brasil, B3
 - Suporta protocolo MCP nativamente (relevante para posicionamento do produto)
 
-**Escavador** (escavador.com/business/api) - Para casos com foco em diarios:
+**Escavador** (escavador.com/business/api) - Para casos com foco em diários:
 - SDK Python oficial no GitHub
 - Busca por CPF/CNPJ/OAB/Nome + webhooks
-- Teor de pecas e diarios oficiais
-- Por credito (modelo pre-pago ou pos-pago)
+- Teor de peças e diários oficiais
+- Por crédito (modelo pré-pago ou pós-pago)
 
-**Jusbrasil Solucoes** (insight.jusbrasil.com.br) - Para compliance/risco:
-- +500 mi processos, motor de decisao < 1 segundo
-- 96 tribunais, 550+ diarios oficiais
-- R$ 1.000/mes entrada
-- Melhor para casos de KYC/AML, nao para monitoramento de prazo
+**Jusbrasil Soluções** (insight.jusbrasil.com.br) - Para compliance/risco:
+- +500 mi processos, motor de decisão < 1 segundo
+- 96 tribunais, 550+ diários oficiais
+- R$ 1.000/mês entrada
+- Melhor para casos de KYC/AML, não para monitoramento de prazo
 
 **Digesto** (digesto.com.br) - Para LegalOps corporativo:
-- Unico com gestao de prazos nativa e workflows BPMN
-- Webhook com 13 tentativas, entrega ~1h apos publicacao em diario
-- Preco nao publico (negociacao comercial)
+- Único com gestão de prazos nativa e workflows BPMN
+- Webhook com 13 tentativas, entrega ~1h após publicação em diário
+- Preço não público (negociação comercial)
 
 **Codilo** (codilo.com.br) - Para alto volume com push puro:
-- Push API sem polling necessario
+- Push API sem polling necessário
 - 95% taxa de acerto declarada
-- Preco nao publico
+- Preço não público
 
-### 2.3 Tabela decisoria por cenario
+### 2.3 Tabela decisória por cenário
 
-| Cenario | Provider recomendado |
+| Cenário | Provider recomendado |
 |---|---|
-| MVP / prototipo (< 500 consultas/mes) | TrackJud + DataJud fallback |
-| Producao B2B escalavel | Judit.io |
-| Compliance financeiro e KYC | Jusbrasil Solucoes |
+| MVP / protótipo (< 500 consultas/mês) | TrackJud + DataJud fallback |
+| Produção B2B escalável | Judit.io |
+| Compliance financeiro e KYC | Jusbrasil Soluções |
 | LegalOps corporativo com BPMN | Digesto |
 | Alto volume com push puro | Codilo |
 
 ---
 
-## 3. Marco Regulatorio
+## 3. Marco Regulatório
 
 ### 3.1 LGPD aplicada a dados processuais
 
-Tensao fundamental: publicidade processual (CF art. 5 LX e 93 IX) vs.
-protecao de dados pessoais (EC 115/2022 como direito fundamental).
+Tensão fundamental: publicidade processual (CF art. 5 LX e 93 IX) vs.
+proteção de dados pessoais (EC 115/2022 como direito fundamental).
 
-Bases legais aplicaveis ao produto:
-- Art. 7 V LGPD: execucao de contrato (servico ao advogado)
-- Art. 7 IX LGPD: legitimo interesse (monitoramento de processo publico)
-- Art. 11 II "d" LGPD: prevencao a fraude (alertas de movimentacao)
+Bases legais aplicáveis ao produto:
+- Art. 7 V LGPD: execução de contrato (serviço ao advogado)
+- Art. 7 IX LGPD: legítimo interesse (monitoramento de processo público)
+- Art. 11 II "d" LGPD: prevenção a fraude (alertas de movimentação)
 
-Dados sensiveis nos autos (saude, origem etnica, orientacao sexual):
-exigem base legal mais robusta. Decisao de design: nao indexar, nao exibir.
+Dados sensíveis nos autos (saúde, origem étnica, orientação sexual):
+exigem base legal mais robusta. Decisão de design: não indexar, não exibir.
 
-### 3.2 Resolucao CNJ 647/2025 - marco central
+### 3.2 Resolução CNJ 647/2025 - marco central
 
-Publicada em 26/09/2025. Pontos criticos para o produto:
-- Compartilhamento formal obrigatorio (convenio ou instrumento equivalente)
+Publicada em 26/09/2025. Pontos críticos para o produto:
+- Compartilhamento formal obrigatório (convênio ou instrumento equivalente)
   para acesso comercial aos dados CNJ/DataJud
-- Proibicao de redistribuicao de base replica (art. 13)
-- Proibicao de reidentificacao de titulares anonimizados
+- Proibição de redistribuição de base réplica (art. 13)
+- Proibição de reidentificação de titulares anonimizados
 - Responsabilidade civil integral do agente privado em incidentes (art. 20)
-- Exige hipotese legal dos arts. 7 e 11 LGPD para acesso de terceiros
+- Exige hipótese legal dos arts. 7 e 11 LGPD para acesso de terceiros
 
-**Acao pre-Fase 1:** Formalizar comunicacao ao CNJ sobre o produto antes
-do lancamento publico.
+**Ação pré-Fase 1:** Formalizar comunicação ao CNJ sobre o produto antes
+do lançamento público.
 
-### 3.3 Segredo de justica
+### 3.3 Segredo de justiça
 
 Fundamento: art. 189 CPC. Processos sigilosos incluem:
-- Acoes de familia (divorcio, guarda, adoção, alimentos) - art. 189 II CPC
-- Processos criminais com risco a intimidade - art. 189 I CPC
+- Ações de família (divórcio, guarda, adoção, alimentos) - art. 189 II CPC
+- Processos criminais com risco à intimidade - art. 189 I CPC
 - ECA (sigilo absoluto para menores)
-- Dados de saude quando o juiz declara sigilo
+- Dados de saúde quando o juiz declara sigilo
 
 O DataJud filtra processos sigilosos na origem (Portaria CNJ 160/2020).
-O produto adiciona verificacao redundante via `nivelSigilo` no parsing.
+O produto adiciona verificação redundante via `nivelSigilo` no parsing.
 
 ### 3.4 OAB - limites do produto
 
 Instrumentos relevantes:
-- Provimento OAB 205/2021: publicidade e marketing juridico
-- Recomendacao OAB 001/2024: diretrizes para IA na advocacia
-- Resolucao CNJ 615/2025: politica de IA no Poder Judiciario (jul/2025)
+- Provimento OAB 205/2021: publicidade e marketing jurídico
+- Recomendação OAB 001/2024: diretrizes para IA na advocacia
+- Resolução CNJ 615/2025: política de IA no Poder Judiciário (jul/2025)
 
 O produto PODE:
-- Resumos de movimentacoes para o advogado
-- Alertas de intimacao e prazo para o advogado
+- Resumos de movimentações para o advogado
+- Alertas de intimação e prazo para o advogado
 - Pesquisa jurisprudencial assistida
-- Geracao de rascunhos com revisao obrigatoria pelo advogado
+- Geração de rascunhos com revisão obrigatória pelo advogado
 
 O produto NUNCA pode:
-- Configurar consultoria juridica direta ao cliente final
+- Configurar consultoria jurídica direta ao cliente final
 - Captar clientela automaticamente
 - Prometer resultado processual
-- Delegar analise juridica integral ao sistema sem revisao do advogado
+- Delegar análise jurídica integral ao sistema sem revisão do advogado
 
 ---
 
@@ -197,69 +197,69 @@ O produto NUNCA pode:
 
 ### 4.1 Dimensionamento
 
-- 1,3 milhao de advogados ativos (OAB, 2025)
+- 1,3 milhão de advogados ativos (OAB, 2025)
 - 600 associados AB2L (ante 20 em 2017) - crescimento acelerado do setor
-- 77% dos escritorios usam algum software de gestao processual
-- 60 horas/mes economizadas com automacao de leitura do DJe (tendencia 2026)
+- 77% dos escritórios usam algum software de gestão processual
+- 60 horas/mês economizadas com automação de leitura do DJe (tendência 2026)
 
 ### 4.2 Mapa de concorrentes
 
-**Segmento autonomo/micro (1-3 advogados):**
+**Segmento autônomo/micro (1-3 advogados):**
 Jusbrasil Pro, Juridiq Jovem Advogado, Astrea Light, Escavador Individual.
-Faixa de preco: R$ 0 a R$ 50/mes.
+Faixa de preço: R$ 0 a R$ 50/mês.
 
-**Segmento escritorio pequeno/medio (4-30 advogados):**
+**Segmento escritório pequeno/médio (4-30 advogados):**
 Astrea Up/Smart, Juridiq Essencial, ADVBOX Essencial, Projuris ADV.
-Faixa de preco: R$ 220 a R$ 439/mes.
+Faixa de preço: R$ 220 a R$ 439/mês.
 
-**Segmento enterprise (30+ advogados / dept. juridico):**
+**Segmento enterprise (30+ advogados / dept. jurídico):**
 Projuris Enterprise, Themis (Aurum), ADVBOX Elite, SAJ ADV.
-Preco sob consulta.
+Preço sob consulta.
 
 ### 4.3 Posicionamento do produto
 
-O MCP Juridico Brasil nao compete diretamente com os SaaS acima.
-E um provedor de dados para assistentes de IA - camada complementar.
-O advogado que ja usa Claude/GPT/Copilot no trabalho ganha acesso
+O MCP Jurídico Brasil não compete diretamente com os SaaS acima.
+É um provedor de dados para assistentes de IA - camada complementar.
+O advogado que já usa Claude/GPT/Copilot no trabalho ganha acesso
 processual dentro do assistente sem trocar de ferramenta.
 
 Lacunas identificadas que o produto preenche:
-1. Integracao nativa de dados processuais em assistentes de IA
-2. Custo zero para consultas basicas (DataJud)
-3. Conformidade LGPD + OAB como diferencial explicito de venda
-4. Ecossistema open-source extensivel (advogado que programa pode contribuir)
+1. Integração nativa de dados processuais em assistentes de IA
+2. Custo zero para consultas básicas (DataJud)
+3. Conformidade LGPD + OAB como diferencial explícito de venda
+4. Ecossistema open-source extensível (advogado que programa pode contribuir)
 
 ---
 
-## 5. Links de Referencia
+## 5. Links de Referência
 
 ### Fontes oficiais
-- [API Publica DataJud - Wiki CNJ](https://datajud-wiki.cnj.jus.br/api-publica/)
+- [API Pública DataJud - Wiki CNJ](https://datajud-wiki.cnj.jus.br/api-publica/)
 - [Acesso API DataJud](https://datajud-wiki.cnj.jus.br/api-publica/acesso/)
-- [Glossario DataJud](https://datajud-wiki.cnj.jus.br/api-publica/glossario/)
-- [Domicilio Judicial Eletronico - PDPJ](https://docs.pdpj.jus.br/servicos-negociais/domicilio-judicial-eletronico/)
-- [Manual DJe 3a Edicao (2025)](https://www.cnj.jus.br/wp-content/uploads/2025/02/manual-domicilio-ed3-2025-1.pdf)
-- [Resolucao CNJ 455/2022](https://atos.cnj.jus.br/atos/detalhar/4509)
-- [Resolucao CNJ 647/2025](https://atos.cnj.jus.br/atos/detalhar/6340)
-- [Resolucao CNJ 615/2025 - IA no Judiciario](https://atos.cnj.jus.br/atos/detalhar/6001)
+- [Glossário DataJud](https://datajud-wiki.cnj.jus.br/api-publica/glossario/)
+- [Domicílio Judicial Eletrônico - PDPJ](https://docs.pdpj.jus.br/servicos-negociais/domicilio-judicial-eletronico/)
+- [Manual DJe 3a Edição (2025)](https://www.cnj.jus.br/wp-content/uploads/2025/02/manual-domicilio-ed3-2025-1.pdf)
+- [Resolução CNJ 455/2022](https://atos.cnj.jus.br/atos/detalhar/4509)
+- [Resolução CNJ 647/2025](https://atos.cnj.jus.br/atos/detalhar/6340)
+- [Resolução CNJ 615/2025 - IA no Judiciário](https://atos.cnj.jus.br/atos/detalhar/6001)
 - [Termo de Uso API DataJud V1.1](https://formularios.cnj.jus.br/wp-content/uploads/2023/05/Termos-de-uso-api-publica-V1.1.pdf)
-- [Padroes de API PJe/MNI](https://docs.pje.jus.br/manuais-basicos/padroes-de-api-do-pje/)
+- [Padrões de API PJe/MNI](https://docs.pje.jus.br/manuais-basicos/padroes-de-api-do-pje/)
 - [Projudi TJPR - Acesso automatizado](https://www.tjpr.jus.br/acesso-automatizado-por-sistemas-externos)
 
-### OAB e regulacao
-- [OAB - Recomendacao 001/2024 - IA na advocacia](https://www.oab.org.br/noticia/62704/oab-aprova-recomendacoes-para-uso-de-ia-na-pratica-juridica)
+### OAB e regulação
+- [OAB - Recomendação 001/2024 - IA na advocacia](https://www.oab.org.br/noticia/62704/oab-aprova-recomendacoes-para-uso-de-ia-na-pratica-juridica)
 - [Provimento OAB 205/2021](https://diario.oab.org.br/pages/materia/842347)
-- [STJ - Segredo de justica nas acoes penais (nov/2024)](https://www.stj.jus.br/sites/portalp/Paginas/Comunicacao/Noticias/2024/11082024-Segredo-de-justica-nas-acoes-penais-o-STJ-entre-o-direito-a-intimidade-e-o-interesse-publico-na-informacao.aspx)
-- [Nota Tecnica TJES 04/2025 - Segredo de Justica](https://www.tjes.jus.br/wp-content/uploads/NOTA-TECNICA-04.2025-ORIENTACOES-PARA-O-USO-ADEQUADO-DA-PRERROGATIVA-SEGREDO-DE-JUSTICA.pdf)
+- [STJ - Segredo de justiça nas ações penais (nov/2024)](https://www.stj.jus.br/sites/portalp/Paginas/Comunicacao/Noticias/2024/11082024-Segredo-de-justica-nas-acoes-penais-o-STJ-entre-o-direito-a-intimidade-e-o-interesse-publico-na-informacao.aspx)
+- [Nota Técnica TJES 04/2025 - Segredo de Justiça](https://www.tjes.jus.br/wp-content/uploads/NOTA-TECNICA-04.2025-ORIENTACOES-PARA-O-USO-ADEQUADO-DA-PRERROGATIVA-SEGREDO-DE-JUSTICA.pdf)
 
 ### APIs comerciais
 - [Escavador - API Business](https://www.escavador.com/business/api)
 - [Judit.io - Planos](https://judit.io/planos/)
 - [Judit.io - Cobertura](https://judit.io/cobertura-dos-tribunais/)
-- [Codilo - Documentacao](https://docs.codilo.com.br/)
+- [Codilo - Documentação](https://docs.codilo.com.br/)
 - [Digesto - LegalOps](https://www.digesto.com.br/legalops-planos)
 - [Jusbrasil - API](https://conteudo.jusbrasil.com.br/api)
-- [TrackJud - Precos](https://trackjud.com.br/pricing)
+- [TrackJud - Preços](https://trackjud.com.br/pricing)
 
 ### Mercado e contexto
 - [Comparativo softwares juridicos 2026 - SquadZ](https://asquadz.ai/blog/softwares-gestao-juridica-comparativo/)

--- a/docs/PLANO-E2E.md
+++ b/docs/PLANO-E2E.md
@@ -1,59 +1,59 @@
-# Plano E2E - MCP Juridico Brasil
+# Plano E2E - MCP Jurídico Brasil
 
 **Autor:** Nikolas de Hor - nikolasdehor79@gmail.com
 **Data:** junho de 2026
-**Versao do plano:** 1.0
+**Versão do plano:** 1.0
 
 ---
 
-## Visao de plataforma modular
+## Visão de plataforma modular
 
-O **MCP Juridico Brasil** e uma plataforma de dados juridicos brasileiros exposta via
-Model Context Protocol (MCP), organizada em **modulos por dominio**. Cada modulo
-e um conjunto coeso de tools, schemas e providers que cobre uma fatia especifica
-do universo juridico. Os modulos sao plugaveis - cada um pode ser evoluido,
-substituido ou monetizado de forma independente.
+O **MCP Jurídico Brasil** é uma plataforma de dados jurídicos brasileiros exposta via
+Model Context Protocol (MCP), organizada em **módulos por domínio**. Cada módulo
+é um conjunto coeso de tools, schemas e providers que cobre uma fatia específica
+do universo jurídico. Os módulos são plugáveis - cada um pode ser evoluído,
+substituído ou monetizado de forma independente.
 
-### Modulo Processual - primeiro modulo (MVP atual)
+### Módulo Processual - primeiro módulo (MVP atual)
 
-O modulo Processual e o que as **Fases 0 a 4** deste plano entregam. Ele cobre:
+O módulo Processual é o que as **Fases 0 a 4** deste plano entregam. Ele cobre:
 
 - Consulta e acompanhamento de processos judiciais em 91 tribunais via DataJud
-- Listagem de movimentacoes com codigos TPU
+- Listagem de movimentações com códigos TPU
 - Monitoramento por polling (Fase 1) e webhook (Fase 3)
-- Calculo de prazos e calendario forense (Fase 2)
-- Intimacoes via Domicilio Judicial Eletronico - DJe (Fase 4)
+- Cálculo de prazos e calendário forense (Fase 2)
+- Intimações via Domicílio Judicial Eletrônico - DJe (Fase 4)
 
-Fonte de dados primaria: **API publica DataJud do CNJ** (gratuita, sem cadastro).
+Fonte de dados primária: **API pública DataJud do CNJ** (gratuita, sem cadastro).
 
-### Modulos futuros plugaveis
+### Módulos futuros plugáveis
 
-Os modulos abaixo entram no roadmap apos a conclusao da Fase 4. A fonte de dados
-de cada um sera validada na fase de planejamento do respectivo modulo.
+Os módulos abaixo entram no roadmap após a conclusão da Fase 4. A fonte de dados
+de cada um será validada na fase de planejamento do respectivo módulo.
 
-| Modulo | Descricao | Fontes candidatas (a validar na fase do modulo) |
+| Módulo | Descrição | Fontes candidatas (a validar na fase do módulo) |
 |---|---|---|
-| **Jurisprudencia** | Decisoes, sumulas e precedentes qualificados | Portais e APIs de STF, STJ, TST e TJs; DJe/PDPJ |
-| **Legislacao** | Leis, decretos, normas e regulamentacoes | LexML (lexml.gov.br), portal Planalto, DOU |
-| **Diarios Oficiais** | Publicacoes e intimacoes em diarios eletronicos | DJEN/CNJ, Querido Diario (Open Knowledge Brasil) |
-| **Calculos Juridicos** | Correcao monetaria, juros legais e prazos processuais | TJSP-JEC, tabelas do CNJ, IPCA/SELIC Banco Central |
+| **Jurisprudência** | Decisões, súmulas e precedentes qualificados | Portais e APIs de STF, STJ, TST e TJs; DJe/PDPJ |
+| **Legislação** | Leis, decretos, normas e regulamentações | LexML (lexml.gov.br), portal Planalto, DOU |
+| **Diários Oficiais** | Publicações e intimações em diários eletrônicos | DJEN/CNJ, Querido Diário (Open Knowledge Brasil) |
+| **Cálculos Jurídicos** | Correção monetária, juros legais e prazos processuais | TJSP-JEC, tabelas do CNJ, IPCA/SELIC Banco Central |
 
-### Como a arquitetura suporta a expansao modular
+### Como a arquitetura suporta a expansão modular
 
-A arquitetura escolhida nas Fases 0-4 foi desenhada para acomodar novos modulos
-sem quebrar o que ja existe:
+A arquitetura escolhida nas Fases 0-4 foi desenhada para acomodar novos módulos
+sem quebrar o que já existe:
 
-- **Pacotes irmaos por dominio:** cada modulo futuro vira um pacote Python ao lado
+- **Pacotes irmãos por domínio:** cada módulo futuro virá um pacote Python ao lado
   de `src/mcp_juridico_brasil/processo/`, `movimentacoes/` etc., seguindo a mesma
-  convencao de diretorios e sem acoplar ao modulo Processual.
-- **Provider abstrato generalizavel:** o `ProcessoProvider` (ABC) e o padrao a ser
-  replicado em cada modulo - um `JurisprudenciaProvider`, um `LegislacaoProvider`,
-  etc. O padrao Strategy ja esta no codigo; basta criar novas implementacoes concretas.
-- **Tools agrupadas por modulo:** cada modulo registra suas proprias tools no
+  convenção de diretórios e sem acoplar ao módulo Processual.
+- **Provider abstrato generalizável:** o `ProcessoProvider` (ABC) é o padrão a ser
+  replicado em cada módulo - um `JurisprudenciaProvider`, um `LegislacaoProvider`,
+  etc. O padrão Strategy já está no código; basta criar novas implementações concretas.
+- **Tools agrupadas por módulo:** cada módulo registra suas próprias tools no
   `server.py` via decorador `@app.tool()`, mantendo o namespace organizado e
-  permitindo ativar ou desativar grupos de tools por configuracao.
-- **Schemas Pydantic por dominio:** cada modulo define seus proprios schemas em
-  `shared/schemas_<dominio>.py`, sem poluir os schemas do modulo Processual.
+  permitindo ativar ou desativar grupos de tools por configuração.
+- **Schemas Pydantic por domínio:** cada módulo define seus próprios schemas em
+  `shared/schemas_<dominio>.py`, sem poluir os schemas do módulo Processual.
 
 ---
 
@@ -61,34 +61,34 @@ sem quebrar o que ja existe:
 
 ### Escolha: Python 3.10+ com FastMCP
 
-O MCP Juridico Brasil adota exatamente a mesma stack do MCP Fiscal Brasil
-(`mcp-fiscal-brasil`), seu projeto irmao:
+O MCP Jurídico Brasil adota exatamente a mesma stack do MCP Fiscal Brasil
+(`mcp-fiscal-brasil`), seu projeto irmão:
 
-| Componente | Escolha | Razao |
+| Componente | Escolha | Razão |
 |---|---|---|
 | Runtime | Python 3.10+ | Compatibilidade com FastMCP, ecossistema data/legal robusto |
-| Framework MCP | fastmcp >= 3.2.0 | Mesma versao do MCP Fiscal; decorator `@app.tool()` simples |
+| Framework MCP | fastmcp >= 3.2.0 | Mesma versão do MCP Fiscal; decorator `@app.tool()` simples |
 | HTTP async | httpx | Cliente async com retry nativo via tenacity |
-| Validacao | pydantic v2 | Schemas tipados, serialization JSON built-in |
+| Validação | pydantic v2 | Schemas tipados, serialization JSON built-in |
 | Rate limiting | aiolimiter | Controla rajadas contra a API DataJud |
-| Cache TTL | cachetools.TTLCache | Evita requisicoes repetidas ao DataJud |
+| Cache TTL | cachetools.TTLCache | Evita requisições repetidas ao DataJud |
 | Retry | tenacity | Exponential backoff para erros 429/5xx |
-| Logging | structlog | Logs estruturados (mesmo padrao do MCP Fiscal) |
-| Config | pydantic-settings | .env -> variaveis de ambiente -> defaults |
+| Logging | structlog | Logs estruturados (mesmo padrão do MCP Fiscal) |
+| Config | pydantic-settings | .env -> variáveis de ambiente -> defaults |
 | CLI | typer | Consistente com o MCP Fiscal |
-| Linter | ruff | Identico ao MCP Fiscal |
-| Typecheck | mypy (strict) | Identico ao MCP Fiscal |
-| Testes | pytest + pytest-asyncio | Identico ao MCP Fiscal |
-| Build | hatchling | Identico ao MCP Fiscal |
-| Package manager | uv | Identico ao MCP Fiscal |
-| CI | GitHub Actions (matrix 3.10-3.13) | Identico ao MCP Fiscal |
+| Linter | ruff | Idêntico ao MCP Fiscal |
+| Typecheck | mypy (strict) | Idêntico ao MCP Fiscal |
+| Testes | pytest + pytest-asyncio | Idêntico ao MCP Fiscal |
+| Build | hatchling | Idêntico ao MCP Fiscal |
+| Package manager | uv | Idêntico ao MCP Fiscal |
+| CI | GitHub Actions (matrix 3.10-3.13) | Idêntico ao MCP Fiscal |
 
-**Por que nao TypeScript/Node?**
+**Por que não TypeScript/Node?**
 O MCP Fiscal usa Python. Manter a mesma stack elimina custo cognitivo de troca
-de contexto, permite reuso de padroes de HTTPClient, config, erros e CI, e
-o ecossistema Python tem bibliotecas maduras para processamento juridico
-(datas, calendarios, NLP em pt-BR). O SDK TypeScript do MCP seria igualmente
-valido tecnicamente, mas a coerencia com o projeto irmao e o fator decisivo.
+de contexto, permite reuso de padrões de HTTPClient, config, erros e CI, e
+o ecossistema Python tem bibliotecas maduras para processamento jurídico
+(datas, calendários, NLP em pt-BR). O SDK TypeScript do MCP seria igualmente
+válido tecnicamente, mas a coerência com o projeto irmão é o fator decisivo.
 
 ---
 
@@ -102,9 +102,9 @@ Claude / qualquer cliente MCP
         | stdio ou HTTP streamable
         v
 +----------------------------+
-|  server.py (FastMCP)       |  <- registro de tools, instrucoes globais
+|  server.py (FastMCP)       |  <- registro de tools, instruções globais
 +----------------------------+
-|  Tools (por modulo)        |
+|  Tools (por módulo)        |
 |  - processo/tools.py       |  buscar_processo_por_numero
 |  - movimentacoes/tools.py  |  listar_movimentacoes
 |  - resumo/tools.py         |  resumir_andamento
@@ -116,24 +116,24 @@ Claude / qualquer cliente MCP
 +----------------------------+
 |  DataJudProvider           |  Fase 1 - gratuito, polling
 |  ComercialProvider         |  Fase 3 - pago, webhook push
-|  DJeProvider               |  Fase 4 - intimacoes proprias
+|  DJeProvider               |  Fase 4 - intimações próprias
 +----------------------------+
 |  DataJudClient             |  Elasticsearch DSL -> DataJud CNJ
 |  HTTPClient (core)         |  retry + rate limit + cache
 +----------------------------+
 |  shared/schemas.py         |  Processo, Movimentacao, Parte, ...
 |  shared/validators.py      |  validar_numero_cnj, normalizar, ...
-|  datajud/tribunais.py      |  mapa sigla -> indice DataJud (91 trib.)
+|  datajud/tribunais.py      |  mapa sigla -> índice DataJud (91 trib.)
 +----------------------------+
 ```
 
 ### 2.2 Tools expostas no MVP (Fase 1)
 
-| Tool | Input | Output | Observacao |
+| Tool | Input | Output | Observação |
 |---|---|---|---|
 | `buscar_processo_por_numero` | numero_processo, tribunal? | dados completos do processo | Verifica sigilo antes de retornar |
-| `listar_movimentacoes` | numero_processo, tribunal, limite? | lista de movimentacoes TPU | Ordenado do mais recente |
-| `resumir_andamento` | numero_processo, tribunal? | dados + instrucao de resumo | Resumo semantico fica no modelo |
+| `listar_movimentacoes` | numero_processo, tribunal, limite? | lista de movimentações TPU | Ordenado do mais recente |
+| `resumir_andamento` | numero_processo, tribunal? | dados + instrução de resumo | Resumo semântico fica no modelo |
 | `monitorar_processo` | numero_processo, tribunal, desde_iso | bool houve_atualizacao | Polling; Fase 3 troca por push |
 | `calcular_proximo_prazo` | numero_processo, tribunal, tipo_ato? | estimativa de prazo | Stub em dias corridos; Fase 2 expande |
 | `listar_tribunais` | (nenhum) | lista de siglas | 91 tribunais suportados |
@@ -142,7 +142,7 @@ Claude / qualquer cliente MCP
 
 Nenhum resource MCP persistente no MVP. Fase 2 adiciona:
 - `resource://processo/{numero}` - snapshot cacheado de processo monitorado
-- `resource://tribunal/{sigla}/status` - status de atualizacao do indice DataJud
+- `resource://tribunal/{sigla}/status` - status de atualização do índice DataJud
 
 ### 2.4 Design do provider abstrato
 
@@ -153,10 +153,10 @@ class ProcessoProvider(ABC):
     async def verificar_atualizacao(numero, tribunal, desde_iso) -> bool: ...
 ```
 
-`DataJudProvider` e a implementacao concreta do MVP. Em Fase 3, o servidor
+`DataJudProvider` é a implementação concreta do MVP. Em Fase 3, o servidor
 detecta `JURIDICO_PROVIDER_COMERCIAL` no ambiente e instancia `ComercialProvider`
 que delega ao Judit, Escavador ou TrackJud via seus SDKs/APIs REST. As tools
-nao mudam - apenas o provider injetado muda. Isso e o padrao Strategy aplicado
+não mudam - apenas o provider injetado muda. Isso é o padrão Strategy aplicado
 ao acesso a dados.
 
 ---
@@ -166,25 +166,25 @@ ao acesso a dados.
 ### Fase 0 - Scaffold (atual)
 
 **Escopo:**
-- Estrutura de diretorios espelhando o MCP Fiscal
+- Estrutura de diretórios espelhando o MCP Fiscal
 - pyproject.toml, server.json, smithery.yaml, .env.example
-- Hierarquia de erros com `JuridicoSigiloError` como cidadao de primeira classe
-- HTTPClient com retry/rate limit/cache (reuso de padroes do MCP Fiscal)
+- Hierarquia de erros com `JuridicoSigiloError` como cidadão de primeira classe
+- HTTPClient com retry/rate limit/cache (reuso de padrões do MCP Fiscal)
 - Schemas Pydantic: Processo, Movimentacao, Parte, OrgaoJulgador
-- Validador de numero CNJ (regex NNNNNNN-DD.AAAA.J.TT.OOOO)
+- Validador de número CNJ (regex NNNNNNN-DD.AAAA.J.TT.OOOO)
 - Mapeamento de 91 tribunais DataJud
 - Stubs de todas as tools com docstrings e disclaimers LGPD/OAB
 - Interface `ProcessoProvider` + `DataJudProvider` (parcialmente implementado)
 - CI GitHub Actions (lint, typecheck, test matrix 3.10-3.13)
-- Testes unitarios de validators
+- Testes unitários de validators
 
-**Criterios de aceite:**
+**Critérios de aceite:**
 - `make lint` passa sem erros
 - `make typecheck` passa
 - `make test` executa e os testes de validators passam
-- Estrutura espelha o MCP Fiscal (revisao manual)
+- Estrutura espelha o MCP Fiscal (revisão manual)
 
-**Estimativa:** 1-2 dias (scaffold ja criado)
+**Estimativa:** 1-2 dias (scaffold já criado)
 
 ---
 
@@ -192,21 +192,21 @@ ao acesso a dados.
 
 **Escopo:**
 - `DataJudClient.buscar_por_numero` funcionando contra a API real
-- `DataJudClient.buscar_por_numero_multiplos_tribunais` com iteracao por tribunal
-- `DataJudClient.listar_movimentacoes` com ordenacao e limite
+- `DataJudClient.buscar_por_numero_multiplos_tribunais` com iteração por tribunal
+- `DataJudClient.listar_movimentacoes` com ordenação e limite
 - `DataJudProvider` completo implementando `ProcessoProvider`
-- Verificacao de `nivelSigilo > 0` integrada ao parsing (bloquear, nao cachelar)
+- Verificação de `nivelSigilo > 0` integrada ao parsing (bloquear, não cachear)
 - Todas as 6 tools retornando dados reais via DataJud
-- Testes de integracao com `respx` (mock do DataJud) para os 4 cenarios:
-  processo publico, processo sigiloso, processo nao encontrado, erro de API
+- Testes de integração com `respx` (mock do DataJud) para os 4 cenários:
+  processo público, processo sigiloso, processo não encontrado, erro de API
 - Exemplo de uso em `examples/consulta_basica.py`
 - Cobertura de testes >= 80%
-- Publicacao no PyPI (versao 0.1.0)
+- Publicação no PyPI (versão 0.1.0)
 
-**Criterios de aceite:**
+**Critérios de aceite:**
 - `buscar_processo_por_numero("0001234-56.2023.8.26.0100", "TJSP")` retorna dados reais
-- Processo com `nivelSigilo=1` lanca `JuridicoSigiloError` com mensagem clara
-- Processo inexistente lanca `JuridicoNotFoundError`
+- Processo com `nivelSigilo=1` lança `JuridicoSigiloError` com mensagem clara
+- Processo inexistente lança `JuridicoNotFoundError`
 - `listar_tribunais()` retorna exatamente 91 entradas
 - CI verde em Python 3.10, 3.11, 3.12, 3.13
 - `uvx mcp-juridico-brasil` funciona no Claude Desktop
@@ -218,22 +218,22 @@ ao acesso a dados.
 ### Fase 2 - Monitoramento e Alertas de Prazo
 
 **Escopo:**
-- `monitorar_processo` com polling agendavel (retorna delta de movimentacoes)
+- `monitorar_processo` com polling agendável (retorna delta de movimentações)
 - `calcular_proximo_prazo` completo:
   - Tabela de prazos CPC (art. 219 e seguintes) por tipo de ato
-  - Calendario forense por UF (feriados nacionais + estaduais)
-  - Deteccao de suspensao de prazo (recesso forense jan/jul)
-  - Diferenciacao entre dias uteis e corridos por tipo de prazo
+  - Calendário forense por UF (feriados nacionais + estaduais)
+  - Detecção de suspensão de prazo (recesso forense jan/jul)
+  - Diferenciação entre dias úteis e corridos por tipo de prazo
 - Resource MCP `processo/{numero}/snapshot` para armazenar estado anterior
-- Comparacao de snapshots para identificar novas movimentacoes
-- Tool `listar_processos_monitorados` (estado em memoria por sessao)
-- Testes de calendario com casos de borda (virada de ano, feriados moveis)
+- Comparação de snapshots para identificar novas movimentações
+- Tool `listar_processos_monitorados` (estado em memória por sessão)
+- Testes de calendário com casos de borda (virada de ano, feriados móveis)
 
-**Criterios de aceite:**
-- Prazo de Embargos de Declaracao (5 dias uteis) calculado corretamente
-  considerando sabados, domingos e feriados nacionais
+**Critérios de aceite:**
+- Prazo de Embargos de Declaração (5 dias úteis) calculado corretamente
+  considerando sábados, domingos e feriados nacionais
 - Recesso forense (20 dez a 20 jan) suspende contagem corretamente
-- `monitorar_processo` retorna apenas movimentacoes novas desde o ultimo check
+- `monitorar_processo` retorna apenas movimentações novas desde o último check
 - Cobertura de testes >= 80%
 
 **Estimativa:** 10-14 dias
@@ -243,154 +243,154 @@ ao acesso a dados.
 ### Fase 3 - Push em Tempo Real via Provider Comercial
 
 **Escopo:**
-- Interface `WebhookProvider` (extensao de `ProcessoProvider`)
-- `ComercialProvider` configuravel via env: Judit, Escavador ou TrackJud
+- Interface `WebhookProvider` (extensão de `ProcessoProvider`)
+- `ComercialProvider` configurável via env: Judit, Escavador ou TrackJud
 - Mecanismo de registro de webhook: tool `registrar_webhook_processo`
-- Recepcao de notificacao push e traducao para o schema interno
-- Fallback automatico para DataJud se o provider comercial estiver indisponivel
-- Documentacao de configuracao de cada provider suportado
-- Preco estimado por consulta documentado no README por provider
+- Recepção de notificação push e tradução para o schema interno
+- Fallback automático para DataJud se o provider comercial estiver indisponível
+- Documentação de configuração de cada provider suportado
+- Preço estimado por consulta documentado no README por provider
 
-**Criterios de aceite:**
-- Com `JURIDICO_PROVIDER_COMERCIAL=judit` e chave valida, `monitorar_processo`
-  retorna notificacao em < 2 horas apos movimentacao (SLA Judit)
+**Critérios de aceite:**
+- Com `JURIDICO_PROVIDER_COMERCIAL=judit` e chave válida, `monitorar_processo`
+  retorna notificação em < 2 horas após movimentação (SLA Judit)
 - Sem provider configurado, todas as tools funcionam normalmente via DataJud
-- Troca de provider nao exige alteracao no codigo das tools
+- Troca de provider não exige alteração no código das tools
 - Cobertura de testes >= 80% (mocks dos providers comerciais)
 
 **Estimativa:** 10-15 dias (depende de acesso a sandbox dos providers)
 
 ---
 
-### Fase 4 - Intimacoes via Domicilio Judicial Eletronico
+### Fase 4 - Intimações via Domicílio Judicial Eletrônico
 
 **Escopo:**
-- `DJeProvider` implementando acesso a API Comunica (DJe/PDPJ)
-- Autenticacao OAuth2 com `client_credentials` via GeCli
-- Tool `listar_intimacoes`: lista comunicacoes pendentes do CNPJ cadastrado
-- Tool `marcar_intimacao_como_lida`: PUT que perfaz a ciencia oficial
-- Tool `buscar_intimacoes_por_processo`: filtra por numero CNJ
+- `DJeProvider` implementando acesso à API Comunica (DJe/PDPJ)
+- Autenticação OAuth2 com `client_credentials` via GeCli
+- Tool `listar_intimacoes`: lista comunicações pendentes do CNPJ cadastrado
+- Tool `marcar_intimacao_como_lida`: PUT que perfaz a ciência oficial
+- Tool `buscar_intimacoes_por_processo`: filtra por número CNJ
 - Aviso claro: `marcar_intimacao_como_lida` inicia contagem de prazo oficial
-- Logs de auditoria imutaveis para cada leitura (header `On-behalf-Of`)
-- Documentacao de credenciamento no portal DJe (exige certificado digital)
+- Logs de auditoria imutáveis para cada leitura (header `On-behalf-Of`)
+- Documentação de credenciamento no portal DJe (exige certificado digital)
 
-**Criterios de aceite:**
-- `listar_intimacoes` retorna comunicacoes reais do CNPJ configurado
-- `marcar_intimacao_como_lida` retorna confirmacao e timestamp da ciencia
-- Tentativa de acessar intimacao de CNPJ diferente do configurado retorna erro
-- Aviso de prazo exibido proeminentemente antes de qualquer marcacao como lida
+**Critérios de aceite:**
+- `listar_intimacoes` retorna comunicações reais do CNPJ configurado
+- `marcar_intimacao_como_lida` retorna confirmação e timestamp da ciência
+- Tentativa de acessar intimação de CNPJ diferente do configurado retorna erro
+- Aviso de prazo exibido proeminentemente antes de qualquer marcação como lida
 - Logs de auditoria persistidos em arquivo local com hash de integridade
 
-**Riscos especificos Fase 4:**
+**Riscos específicos Fase 4:**
 - O portal DJe exige credenciamento com certificado digital ICP-Brasil
-  (e-CNPJ ou e-CPF) - nao pode ser automatizado completamente
-- A API OAuth2 do DJe teve migracao obrigatoria ate 31/03/2026;
-  verificar se a versao atual e compativel antes de implementar
-- Marcar como lida via API tem efeito juridico real (inicia prazo);
-  exigir confirmacao explicita do usuario antes de executar
+  (e-CNPJ ou e-CPF) - não pode ser automatizado completamente
+- A API OAuth2 do DJe teve migração obrigatória até 31/03/2026;
+  verificar se a versão atual é compatível antes de implementar
+- Marcar como lida via API tem efeito jurídico real (inicia prazo);
+  exigir confirmação explícita do usuário antes de executar
 
 **Estimativa:** 15-20 dias
 
 ---
 
-### Pos-Fase 4 - Abertura dos proximos modulos
+### Pós-Fase 4 - Abertura dos próximos módulos
 
-Com o modulo Processual maduro e publicado, os proximos modulos entram em
-planejamento seguindo o mesmo ciclo: definicao de fontes, scaffold, MVP, expansao.
+Com o módulo Processual maduro e publicado, os próximos módulos entram em
+planejamento seguindo o mesmo ciclo: definição de fontes, scaffold, MVP, expansão.
 
-Ordem tentativa (sujeita a validacao de demanda):
+Ordem tentativa (sujeita a validação de demanda):
 
-1. **Jurisprudencia** - alta sinergia com o modulo Processual (processos citam acórdaos)
-2. **Diarios Oficiais** - complemento natural ao modulo DJe da Fase 4
-3. **Legislacao** - base de referencia para os demais modulos
-4. **Calculos Juridicos** - modulo transversal, pode ser entregue em paralelo com qualquer outro
+1. **Jurisprudência** - alta sinergia com o módulo Processual (processos citam acórdãos)
+2. **Diários Oficiais** - complemento natural ao módulo DJe da Fase 4
+3. **Legislação** - base de referência para os demais módulos
+4. **Cálculos Jurídicos** - módulo transversal, pode ser entregue em paralelo com qualquer outro
 
-Cada modulo tera seu proprio PLANO-E2E, versionamento de API e politica de
-compatibilidade. Modulos existentes nao serao quebrados por modulos novos.
+Cada módulo terá seu próprio PLANO-E2E, versionamento de API e política de
+compatibilidade. Módulos existentes não serão quebrados por módulos novos.
 
 ---
 
-## 4. Riscos e Mitigacoes (como Requisitos de Design)
+## 4. Riscos e Mitigações (como Requisitos de Design)
 
-### 4.1 Segredo de justica (CRITICO)
+### 4.1 Segredo de justiça (CRÍTICO)
 
-**Risco:** Expor dados de processo sigiloso para usuario nao autorizado.
+**Risco:** Expor dados de processo sigiloso para usuário não autorizado.
 
-**Mitigacao embutida no design:**
-- `JuridicoSigiloError` e verificado ANTES de qualquer retorno de dados
-- Processos com `nivelSigilo > 0` nao sao cacheados (nem no TTLCache)
-- Logs de processos sigilosos registram apenas numero e nivel, nunca conteudo
+**Mitigação embutida no design:**
+- `JuridicoSigiloError` é verificado ANTES de qualquer retorno de dados
+- Processos com `nivelSigilo > 0` não são cacheados (nem no TTLCache)
+- Logs de processos sigilosos registram apenas número e nível, nunca conteúdo
 - Nenhum fallback para "tentar outro provider" quando o DataJud bloqueia por sigilo
 - Fundamento: art. 189 CPC + Portaria CNJ 160/2020 (DataJud filtra na origem)
 
-**Implementacao:** `datajud/client.py` - metodo `_parse_processo` verifica
-`nivelSigilo` antes de construir o objeto `Processo`. Qualquer valor > 0 lanca
+**Implementação:** `datajud/client.py` - método `_parse_processo` verifica
+`nivelSigilo` antes de construir o objeto `Processo`. Qualquer valor > 0 lança
 `JuridicoSigiloError` imediatamente, sem retornar dados parciais.
 
 ### 4.2 LGPD - dados pessoais de partes (ALTO)
 
-**Risco:** Tratar CPF/CNPJ de partes, dados de saude ou dados sensiveis
-sem base legal adequada ou alem do necessario.
+**Risco:** Tratar CPF/CNPJ de partes, dados de saúde ou dados sensíveis
+sem base legal adequada ou além do necessário.
 
-**Mitigacao embutida no design:**
-- Schema `Parte` nao tem campo CPF/CNPJ (a API DataJud nao indexa por razoes de LGPD)
-- Campos de dados sensiveis (saude, orientacao sexual, origem etnica) nao existem
-  nos schemas - se estiverem nos complementos, nao sao indexados
-- Retencao: dados em memoria apenas durante a sessao MCP ativa
+**Mitigação embutida no design:**
+- Schema `Parte` não tem campo CPF/CNPJ (a API DataJud não indexa por razões de LGPD)
+- Campos de dados sensíveis (saúde, orientação sexual, origem étnica) não existem
+  nos schemas - se estiverem nos complementos, não são indexados
+- Retenção: dados em memória apenas durante a sessão MCP ativa
 - Nenhum banco de dados local ou cache persistente no MVP
 
-**Base legal adotada:** art. 7, IX LGPD (legitimo interesse do advogado
-no acompanhamento de processos de seus clientes) + art. 7, V (execucao
-de contrato de servico com o advogado).
+**Base legal adotada:** art. 7, IX LGPD (legítimo interesse do advogado
+no acompanhamento de processos de seus clientes) + art. 7, V (execução
+de contrato de serviço com o advogado).
 
-### 4.3 Resolucao CNJ 647/2025 - uso comercial do DataJud (ALTO)
+### 4.3 Resolução CNJ 647/2025 - uso comercial do DataJud (ALTO)
 
-**Risco:** Usar DataJud como base de produto comercial sem formalizacao
-com o CNJ pode ser contestado. Art. 13 proibe redistribuicao de base replica.
+**Risco:** Usar DataJud como base de produto comercial sem formalização
+com o CNJ pode ser contestado. Art. 13 proíbe redistribuição de base réplica.
 
-**Mitigacao embutida no design:**
-- Arquitetura "query on demand": nenhuma base replica e mantida localmente
+**Mitigação embutida no design:**
+- Arquitetura "query on demand": nenhuma base réplica é mantida localmente
 - Cada consulta busca em tempo real na API DataJud
-- Cache TTL curto (300s padrao) para uso normal, nao para replicacao
-- Termos de uso do produto proibem exportacao em massa pelo usuario
-- Recomendacao: formalizar relacionamento com CNJ via comunicacao oficial
-  antes do lancamento publico (acao pre-Fase 1)
+- Cache TTL curto (300s padrão) para uso normal, não para replicação
+- Termos de uso do produto proíbem exportação em massa pelo usuário
+- Recomendação: formalizar relacionamento com CNJ via comunicação oficial
+  antes do lançamento público (ação pré-Fase 1)
 
-### 4.4 OAB - exercicio da advocacia / captacao indevida (ALTO)
+### 4.4 OAB - exercício da advocacia / captação indevida (ALTO)
 
-**Risco:** Funcionalidade que configure consultoria juridica direta ou
-captacao automatizada de clientela, vedada pelo CED OAB e
+**Risco:** Funcionalidade que configure consultoria jurídica direta ou
+captação automatizada de clientela, vedada pelo CED OAB e
 Provimento OAB 205/2021.
 
-**Mitigacao embutida no design:**
-- Disclaimer obrigatorio em TODAS as tools e no campo `instructions` do servidor
-- `resumir_andamento` retorna dados + instrucao de resumo, nao "conselho juridico"
+**Mitigação embutida no design:**
+- Disclaimer obrigatório em TODAS as tools e no campo `instructions` do servidor
+- `resumir_andamento` retorna dados + instrução de resumo, não "conselho jurídico"
 - Nenhuma tool envia mensagens a clientes finais ou terceiros
 - Produto posicionado como ferramenta para o advogado, nunca para o cliente final
-- Termos de uso do produto vederao uso direto por clientes sem intermediacao
+- Termos de uso do produto vedará uso direto por clientes sem intermediação
 
-### 4.5 Rotacao da chave DataJud pelo CNJ (MEDIO)
+### 4.5 Rotação da chave DataJud pelo CNJ (MÉDIO)
 
-**Risco:** O CNJ pode rotacionar a APIKey publica sem aviso previo.
+**Risco:** O CNJ pode rotacionar a APIKey pública sem aviso prévio.
 
-**Mitigacao:** Chave configuravel via `DATAJUD_API_KEY` no .env. Fallback
-de erro explicito com link para a wiki do CNJ. SLA interno: readequar em 48h
-apos notificacao de revogacao.
+**Mitigação:** Chave configurável via `DATAJUD_API_KEY` no .env. Fallback
+de erro explícito com link para a wiki do CNJ. SLA interno: readequar em 48h
+após notificação de revogação.
 
-### 4.6 Defasagem DataJud em prazos criticos (MEDIO)
+### 4.6 Defasagem DataJud em prazos críticos (MÉDIO)
 
-**Risco:** Advogado usa `calcular_proximo_prazo` baseado em movimentacao
+**Risco:** Advogado usa `calcular_proximo_prazo` baseado em movimentação
 desatualizada e perde o prazo real.
 
-**Mitigacao embutida no design:**
-- Aviso de defasagem em TODOS os retornos de prazo (campo `aviso` obrigatorio)
-- `calcular_proximo_prazo` tem campo `limitacao` explicitando que e estimativa
-- Documentacao orienta uso de provider comercial (Fase 3) para prazos criticos
-- Disclaimer no README e nas instrucoes do servidor MCP
+**Mitigação embutida no design:**
+- Aviso de defasagem em TODOS os retornos de prazo (campo `aviso` obrigatório)
+- `calcular_proximo_prazo` tem campo `limitacao` explicitando que é estimativa
+- Documentação orienta uso de provider comercial (Fase 3) para prazos críticos
+- Disclaimer no README e nas instruções do servidor MCP
 
 ---
 
-## 5. Posicionamento e Monetizacao
+## 5. Posicionamento e Monetização
 
 ### 5.1 Modelo: core open-source + camada paga opcional
 
@@ -400,66 +400,66 @@ desatualizada e perde o prazo real.
 | - DataJud (91 tribunais, polling)        |
 | - Todas as 6 tools do MVP               |
 | - Sem limite de processos locais         |
-| - Sem cadastro ou API key propria        |
+| - Sem cadastro ou API key própria        |
 +------------------------------------------+
           |
           v
 +------------------------------------------+
 | CAMADA PAGA (futura - Fase 3+)           |
 | - Provider comercial (webhook push)      |
-| - Monitoramento continuo multi-processo  |
+| - Monitoramento contínuo multi-processo  |
 | - Alertas em tempo real                  |
-| - Integracao DJe (intimacoes oficiais)   |
+| - Integração DJe (intimações oficiais)   |
 +------------------------------------------+
 ```
 
-O modelo espelha o MCP Fiscal Brasil: funcionalidade basica gratuita e util
-para o publico geral; camada paga para casos de uso profissional em escala.
+O modelo espelha o MCP Fiscal Brasil: funcionalidade básica gratuita e útil
+para o público geral; camada paga para casos de uso profissional em escala.
 
-### 5.2 Publico-alvo e proposta de valor
+### 5.2 Público-alvo e proposta de valor
 
-**Primario:** Advogado autonomo e escritorio pequeno (1-5 advogados)
+**Primário:** Advogado autônomo e escritório pequeno (1-5 advogados)
 
-- Dor principal: perda de prazo por nao monitorar DJe e portal do tribunal
+- Dor principal: perda de prazo por não monitorar DJe e portal do tribunal
 - Proposta: consulta processual direto no Claude/assistente de IA sem
-  sair do fluxo de trabalho. Sem login em portal, sem copiar/colar numero.
+  sair do fluxo de trabalho. Sem login em portal, sem copiar/colar número.
 - Barreira de entrada: zero (open-source, sem cadastro, sem custo inicial)
 
-**Secundario:** Desenvolvedor de legaltech
+**Secundário:** Desenvolvedor de legaltech
 
-- Dor: construir integracao DataJud do zero para cada produto
-- Proposta: provider abstraido, schemas Pydantic prontos, CI configurado,
+- Dor: construir integração DataJud do zero para cada produto
+- Proposta: provider abstraído, schemas Pydantic prontos, CI configurado,
   tratamento de sigilo e LGPD embutidos
 
-### 5.3 Diferenciacao em relacao aos concorrentes
+### 5.3 Diferenciação em relação aos concorrentes
 
-Os concorrentes diretos (Jusbrasil Pro, Juridiq, Astrea, ADVBOX) sao
-plataformas SaaS com interface web propria. O MCP Juridico Brasil e
+Os concorrentes diretos (Jusbrasil Pro, Juridiq, Astrea, ADVBOX) são
+plataformas SaaS com interface web própria. O MCP Jurídico Brasil é
 um provedor de dados para assistentes de IA - posicionamento complementar,
-nao substituto. O advogado que ja usa Claude/Copilot/GPT no dia a dia
+não substituto. O advogado que já usa Claude/Copilot/GPT no dia a dia
 ganha acesso processual sem trocar de ferramenta.
 
-### 5.4 Caminho para monetizacao (Fase 3+)
+### 5.4 Caminho para monetização (Fase 3+)
 
-Opcoes a avaliar apos validacao do MVP:
-1. **API key propria paga** para acesso ao provider comercial embutido
+Opções a avaliar após validação do MVP:
+1. **API key própria paga** para acesso ao provider comercial embutido
    (repassar custo do Judit/Escavador com margem)
-2. **Plano mensal** para monitoramento continuo com webhook e alertas
-   (R$ 29-49/mes para ate 100 processos monitorados)
-3. **Plugin pago no Smithery/MCP Registry** para usuarios que nao querem
-   configurar infraestrutura propria
+2. **Plano mensal** para monitoramento contínuo com webhook e alertas
+   (R$ 29-49/mês para até 100 processos monitorados)
+3. **Plugin pago no Smithery/MCP Registry** para usuários que não querem
+   configurar infraestrutura própria
 
-Nao ha plano de cobrar pelo acesso ao DataJud (que e publico e gratuito).
+Não há plano de cobrar pelo acesso ao DataJud (que é público e gratuito).
 
 ---
 
-## 6. Dependencias de Terceiros e Licencas
+## 6. Dependências de Terceiros e Licenças
 
-| Dependencia | Versao minima | Licenca | Uso |
+| Dependência | Versão mínima | Licença | Uso |
 |---|---|---|---|
 | fastmcp | 3.2.0 | MIT | Framework MCP |
 | httpx | 0.27.0 | BSD | HTTP async |
-| pydantic | 2.0 | MIT | Schemas e validacao |
+| pydantic | 2.0 | MIT | Schemas e validação |
 | pydantic-settings | 2.13.1 | MIT | Config via env |
 | python-dateutil | 2.9.0 | Apache 2.0 | Parsing de datas |
 | tenacity | 9.1.4 | Apache 2.0 | Retry com backoff |
@@ -468,4 +468,4 @@ Nao ha plano de cobrar pelo acesso ao DataJud (que e publico e gratuito).
 | structlog | 25.5.0 | MIT | Logging estruturado |
 | typer | 0.25.1 | MIT | CLI |
 
-Todas as dependencias sao compatíveis com licenca MIT do projeto.
+Todas as dependências são compatíveis com licença MIT do projeto.

--- a/src/mcp_juridico_brasil/_core/config.py
+++ b/src/mcp_juridico_brasil/_core/config.py
@@ -1,10 +1,10 @@
-"""Configuracao de runtime do mcp-juridico-brasil."""
+"""Configuração de runtime do mcp-juridico-brasil."""
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    """Configuracoes carregadas de variaveis de ambiente ou arquivo .env."""
+    """Configurações carregadas de variáveis de ambiente ou arquivo .env."""
 
     # Ambiente
     juridico_env: str = "development"
@@ -17,10 +17,10 @@ class Settings(BaseSettings):
     juridico_max_retries: int = 3
 
     # DataJud CNJ (Fase 1)
-    # Chave publica divulgada pelo proprio CNJ na wiki oficial do DataJud.
-    # Nao e credencial privada - qualquer usuario pode obte-la sem cadastro.
-    # ATENCAO: as credenciais das Fases 3/4 (juridico_provider_api_key,
-    # dje_client_id, dje_client_secret) sao PRIVADAS e NAO devem ter default.
+    # Chave pública divulgada pelo próprio CNJ na wiki oficial do DataJud.
+    # Não é credencial privada - qualquer usuário pode obtê-la sem cadastro.
+    # ATENÇÃO: as credenciais das Fases 3/4 (juridico_provider_api_key,
+    # dje_client_id, dje_client_secret) são PRIVADAS e NÃO devem ter default.
     # Ao rotacionar, definir DATAJUD_API_KEY no ambiente e remover este default.
     datajud_api_key: str = "cDZHYzlZa0JadVREZDJCendQbXY6SkJlTzNjLV9TRENyQk1RdnFKZGRQdw=="
     datajud_base_url: str = "https://api-publica.datajud.cnj.jus.br"
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     juridico_provider_comercial: str = ""
     juridico_provider_api_key: str = ""
 
-    # Domicilio Judicial Eletronico (Fase 4 - opcional)
+    # Domicílio Judicial Eletrônico (Fase 4 - opcional)
     dje_client_id: str = ""
     dje_client_secret: str = ""
     dje_behalf_of_cpf: str = ""

--- a/src/mcp_juridico_brasil/_core/errors.py
+++ b/src/mcp_juridico_brasil/_core/errors.py
@@ -6,7 +6,7 @@ from typing import Any
 
 
 class JuridicoError(Exception):
-    """Erro base do MCP Juridico Brasil."""
+    """Erro base do MCP Jurídico Brasil."""
 
     def __init__(self, message: str, detail: dict[str, Any] | None = None) -> None:
         super().__init__(message)
@@ -15,28 +15,28 @@ class JuridicoError(Exception):
 
 
 class JuridicoValidationError(JuridicoError):
-    """Dados de entrada invalidos (numero CNJ malformado, tribunal desconhecido, etc.)."""
+    """Dados de entrada inválidos (número CNJ malformado, tribunal desconhecido, etc.)."""
 
     def __init__(self, field: str, value: str, reason: str) -> None:
         super().__init__(
-            f"Valor invalido para '{field}': {value!r}. {reason}",
+            f"Valor inválido para '{field}': {value!r}. {reason}",
             detail={"field": field, "value": value, "reason": reason},
         )
 
 
 class JuridicoNotFoundError(JuridicoError):
-    """Processo ou recurso nao encontrado na fonte de dados."""
+    """Processo ou recurso não encontrado na fonte de dados."""
 
     def __init__(self, numero_processo: str, tribunal: str | None = None) -> None:
         where = f" no tribunal {tribunal}" if tribunal else ""
         super().__init__(
-            f"Processo {numero_processo} nao encontrado{where}.",
+            f"Processo {numero_processo} não encontrado{where}.",
             detail={"numero_processo": numero_processo, "tribunal": tribunal},
         )
 
 
 class JuridicoAPIError(JuridicoError):
-    """Falha na comunicacao com API externa (DataJud, provider comercial, DJe)."""
+    """Falha na comunicação com API externa (DataJud, provider comercial, DJe)."""
 
     def __init__(self, source: str, status_code: int | None = None, reason: str = "") -> None:
         msg = f"Falha ao acessar {source}"
@@ -48,18 +48,18 @@ class JuridicoAPIError(JuridicoError):
 
 
 class JuridicoSigiloError(JuridicoError):
-    """Processo em segredo de justica - acesso bloqueado por politica de privacidade.
+    """Processo em segredo de justiça - acesso bloqueado por política de privacidade.
 
-    Este erro DEVE ser propagado ao usuario com mensagem clara. Nao tente contornar
+    Este erro DEVE ser propagado ao usuário com mensagem clara. Não tente contornar
     o sigilo consultando outras fontes ou usando providers comerciais.
-    Fundamento legal: art. 189 do CPC e Resolucao CNJ 647/2025.
+    Fundamento legal: art. 189 do CPC e Resolução CNJ 647/2025.
     """
 
     def __init__(self, numero_processo: str, nivel_sigilo: int) -> None:
         super().__init__(
-            f"O processo {numero_processo} esta em segredo de justica "
-            f"(nivel {nivel_sigilo}) e nao pode ser acessado por esta ferramenta. "
-            "Acesso restrito as partes e seus advogados via portal do tribunal.",
+            f"O processo {numero_processo} está em segredo de justiça "
+            f"(nível {nivel_sigilo}) e não pode ser acessado por esta ferramenta. "
+            "Acesso restrito às partes e seus advogados via portal do tribunal.",
             detail={"numero_processo": numero_processo, "nivel_sigilo": nivel_sigilo},
         )
 

--- a/src/mcp_juridico_brasil/_core/http.py
+++ b/src/mcp_juridico_brasil/_core/http.py
@@ -25,7 +25,7 @@ def _is_retryable(exc: BaseException) -> bool:
 
 
 class HTTPClient:
-    """Cliente JSON async para servicos externos do MCP Juridico Brasil."""
+    """Cliente JSON async para serviços externos do MCP Jurídico Brasil."""
 
     def __init__(
         self,
@@ -58,7 +58,7 @@ class HTTPClient:
             self._client = None
 
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
-        """GET com cache TTL e retry automatico."""
+        """GET com cache TTL e retry automático."""
         cache_key = f"GET:{path}:{params}"
         if cache_key in self._cache:
             return self._cache[cache_key]
@@ -73,7 +73,7 @@ class HTTPClient:
 
     async def _request(self, method: str, path: str, **kwargs: Any) -> Any:
         if self._client is None:
-            raise RuntimeError("HTTPClient nao inicializado. Use como context manager.")
+            raise RuntimeError("HTTPClient não inicializado. Use como context manager.")
 
         async with self._limiter:
             async for attempt in AsyncRetrying(

--- a/src/mcp_juridico_brasil/_core/logging.py
+++ b/src/mcp_juridico_brasil/_core/logging.py
@@ -1,4 +1,4 @@
-"""Configuracao de logging estruturado com structlog."""
+"""Configuração de logging estruturado com structlog."""
 
 from __future__ import annotations
 
@@ -9,12 +9,12 @@ import structlog
 
 
 def get_logger(name: str) -> structlog.stdlib.BoundLogger:
-    """Retorna um logger estruturado para o modulo informado."""
+    """Retorna um logger estruturado para o módulo informado."""
     return cast(structlog.stdlib.BoundLogger, structlog.get_logger(name))
 
 
 def configure_logging(level: str = "INFO") -> None:
-    """Configura o pipeline do structlog para o ambiente de execucao."""
+    """Configura o pipeline do structlog para o ambiente de execução."""
     logging.basicConfig(
         format="%(message)s",
         level=getattr(logging, level.upper(), logging.INFO),

--- a/src/mcp_juridico_brasil/datajud/client.py
+++ b/src/mcp_juridico_brasil/datajud/client.py
@@ -1,10 +1,10 @@
 """Cliente DataJud CNJ.
 
-Consome a API publica Elasticsearch do DataJud (Portaria CNJ 160/2020).
-Chave de acesso publica - sem cadastro. Rotacionar se o CNJ revogar.
+Consome a API pública Elasticsearch do DataJud (Portaria CNJ 160/2020).
+Chave de acesso pública - sem cadastro. Rotacionar se o CNJ revogar.
 
-NOTA DE SEGURANCA: Esta implementacao verifica nivel_sigilo antes de retornar
-qualquer dado. Processos sigilosos lancam JuridicoSigiloError e NAO sao
+NOTA DE SEGURANÇA: Esta implementação verifica nivel_sigilo antes de retornar
+qualquer dado. Processos sigilosos lançam JuridicoSigiloError e NÃO são
 armazenados em cache nem em logs detalhados.
 """
 
@@ -31,15 +31,15 @@ logger = get_logger(__name__)
 
 
 class DataJudClient:
-    """Acesso a API publica DataJud com verificacao de sigilo integrada."""
+    """Acesso à API pública DataJud com verificação de sigilo integrada."""
 
     def _http(self, tribunal: str) -> HTTPClient:
         url = indice_para_url(tribunal, _settings.datajud_base_url)
         if not url:
             raise JuridicoAPIError(
                 source="DataJud",
-                reason=f"Tribunal '{tribunal}' nao suportado. "
-                f"Consulte listar_tribunais() para opcoes validas.",
+                reason=f"Tribunal '{tribunal}' não suportado. "
+                f"Consulte listar_tribunais() para opções válidas.",
             )
         return HTTPClient(
             base_url=url,
@@ -51,12 +51,12 @@ class DataJudClient:
         )
 
     async def buscar_por_numero(self, numero_processo: str, tribunal: str) -> Processo:
-        """Busca um processo pelo numero CNJ em um tribunal especifico.
+        """Busca um processo pelo número CNJ em um tribunal específico.
 
         Raises:
             JuridicoSigiloError: Se nivel_sigilo > 0.
-            JuridicoNotFoundError: Se o processo nao existir no indice.
-            JuridicoAPIError: Em falhas de comunicacao.
+            JuridicoNotFoundError: Se o processo não existir no índice.
+            JuridicoAPIError: Em falhas de comunicação.
         """
         query = {"query": {"match": {"numeroProcesso": numero_processo}}, "size": 1}
         async with self._http(tribunal) as client:
@@ -73,10 +73,10 @@ class DataJudClient:
         numero_processo: str,
         tribunais: list[str] | None = None,
     ) -> Processo:
-        """Tenta localizar o processo em multiplos tribunais.
+        """Tenta localizar o processo em múltiplos tribunais.
 
-        Util quando o tribunal nao e conhecido de antemao.
-        Itera pelos tribunais informados (ou por todos os suportados) ate
+        Útil quando o tribunal não é conhecido de antemão.
+        Itera pelos tribunais informados (ou por todos os suportados) até
         encontrar o processo.
         """
         targets = tribunais or listar_tribunais()

--- a/src/mcp_juridico_brasil/datajud/provider.py
+++ b/src/mcp_juridico_brasil/datajud/provider.py
@@ -1,7 +1,7 @@
-"""Interface abstrata ProcessoProvider e implementacao DataJudProvider.
+"""Interface abstrata ProcessoProvider e implementação DataJudProvider.
 
 O design de provider abstrato permite trocar a fonte de dados sem alterar
-as tools MCP. Em producao, um provider comercial (Judit, Escavador) pode
+as tools MCP. Em produção, um provider comercial (Judit, Escavador) pode
 substituir o DataJud para tribunais com maior defasagem ou para consultas
 por CPF/CNPJ.
 
@@ -31,19 +31,19 @@ class ProcessoProvider(ABC):
     async def listar_movimentacoes(
         self, numero_processo: str, tribunal: str, limite: int = 20
     ) -> list[Movimentacao]:
-        """Retorna as movimentacoes mais recentes."""
+        """Retorna as movimentações mais recentes."""
         ...
 
     @abstractmethod
     async def verificar_atualizacao(
         self, numero_processo: str, tribunal: str, desde_iso: str
     ) -> bool:
-        """Retorna True se o processo teve atualizacao apos a data informada."""
+        """Retorna True se o processo teve atualização após a data informada."""
         ...
 
 
 class DataJudProvider(ProcessoProvider):
-    """Provider concreto baseado na API publica DataJud (CNJ).
+    """Provider concreto baseado na API pública DataJud (CNJ).
 
     Cobertura: 91 tribunais. Zero custo. Sem webhook (polling).
     Defasagem: T+1 a T+7 dias dependendo do tribunal.

--- a/src/mcp_juridico_brasil/monitoramento/store.py
+++ b/src/mcp_juridico_brasil/monitoramento/store.py
@@ -1,18 +1,18 @@
 """Store de snapshots de processos monitorados.
 
-Guarda o ultimo snapshot (dados + timestamp) por numero de processo.
-Persistencia em memoria por sessao MCP; persistencia em arquivo JSON
+Guarda o último snapshot (dados + timestamp) por número de processo.
+Persistência em memória por sessão MCP; persistência em arquivo JSON
 opcional via JURIDICO_SNAPSHOT_DIR no ambiente.
 
-Decisao de design (Fase 2):
-- Store em memoria e suficiente para o caso de uso de sessao unica
-- Arquivo JSON local oferece persistencia simples entre reinicializacoes
+Decisão de design (Fase 2):
+- Store em memória é suficiente para o caso de uso de sessão única
+- Arquivo JSON local oferece persistência simples entre reinicializações
 - Banco de dados relacional ou Redis fica para Fase 3+ (multi-tenant, escala)
 
-Limitacoes documentadas:
-- Estado em memoria se perde ao reiniciar o servidor MCP
-- Sem controle de concorrencia (apenas asyncio, sem multiprocessing)
-- Sem expiracao automatica de snapshots (ficar indefinidamente na memoria)
+Limitações documentadas:
+- Estado em memória se perde ao reiniciar o servidor MCP
+- Sem controle de concorrência (apenas asyncio, sem multiprocessing)
+- Sem expiração automática de snapshots (ficam indefinidamente na memória)
 """
 
 from __future__ import annotations
@@ -80,9 +80,9 @@ def salvar_snapshot(
     """Salva snapshot de um processo monitorado.
 
     Args:
-        numero_processo: Numero CNJ normalizado do processo.
+        numero_processo: Número CNJ normalizado do processo.
         tribunal: Sigla do tribunal.
-        dados: Dicionario com dados do processo (saida de buscar_processo_por_numero).
+        dados: Dicionário com dados do processo (saída de buscar_processo_por_numero).
 
     Returns:
         Snapshot salvo com metadados de timestamp.
@@ -101,15 +101,15 @@ def salvar_snapshot(
 
 
 def obter_snapshot(numero_processo: str) -> dict[str, Any] | None:
-    """Recupera o ultimo snapshot de um processo.
+    """Recupera o último snapshot de um processo.
 
-    Busca primeiro na memoria; se nao encontrar, tenta o arquivo local.
+    Busca primeiro na memória; se não encontrar, tenta o arquivo local.
 
     Args:
-        numero_processo: Numero CNJ normalizado do processo.
+        numero_processo: Número CNJ normalizado do processo.
 
     Returns:
-        Snapshot ou None se nao houver.
+        Snapshot ou None se não houver.
     """
     with _lock:
         em_memoria = _snapshots.get(numero_processo)
@@ -134,13 +134,13 @@ def listar_processos_monitorados() -> list[str]:
 
 
 def remover_snapshot(numero_processo: str) -> bool:
-    """Remove snapshot de um processo da memoria e do disco.
+    """Remove snapshot de um processo da memória e do disco.
 
     Args:
-        numero_processo: Numero CNJ normalizado.
+        numero_processo: Número CNJ normalizado.
 
     Returns:
-        True se havia snapshot e foi removido; False se nao existia.
+        True se havia snapshot e foi removido; False se não existia.
     """
     with _lock:
         existia = numero_processo in _snapshots

--- a/src/mcp_juridico_brasil/monitoramento/tools.py
+++ b/src/mcp_juridico_brasil/monitoramento/tools.py
@@ -21,25 +21,25 @@ async def monitorar_processo(
     tribunal: str,
     desde_iso: str,
 ) -> dict[str, object]:
-    """Verifica se um processo teve atualizacao apos a data informada.
+    """Verifica se um processo teve atualização após a data informada.
 
-    Implementacao Fase 2: polling via DataJud (sem tempo real).
-    Fase 3 substituira por notificacao push via provider comercial.
+    Implementação Fase 2: polling via DataJud (sem tempo real).
+    Fase 3 substituirá por notificação push via provider comercial.
 
     Args:
-        numero_processo: Numero no formato CNJ.
-        tribunal: Sigla do tribunal (obrigatoria para monitoramento).
-        desde_iso: Data/hora de referencia em formato ISO 8601
+        numero_processo: Número no formato CNJ.
+        tribunal: Sigla do tribunal (obrigatória para monitoramento).
+        desde_iso: Data/hora de referência em formato ISO 8601
                    (ex: '2024-01-15T08:00:00').
 
     Returns:
-        Dicionario indicando se houve atualizacao e a data da ultima.
+        Dicionário indicando se houve atualização e a data da última.
     """
     if not validar_numero_cnj(numero_processo):
         raise JuridicoValidationError(
             field="numero_processo",
             value=numero_processo,
-            reason="Formato invalido. Use o padrao CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO.",
+            reason="Formato inválido. Use o padrão CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO.",
         )
 
     try:
@@ -48,7 +48,7 @@ async def monitorar_processo(
         raise JuridicoValidationError(
             field="desde_iso",
             value=desde_iso,
-            reason="Data invalida. Use formato ISO 8601: YYYY-MM-DDTHH:MM:SS",
+            reason="Data inválida. Use formato ISO 8601: YYYY-MM-DDTHH:MM:SS",
         ) from exc
 
     numero_normalizado = normalizar_numero_cnj(numero_processo)
@@ -76,7 +76,7 @@ async def monitorar_processo(
         "data_ultima_atualizacao_datajud": ultima_iso,
         "aviso_defasagem": (
             "O DataJud pode ter atraso de T+1 a T+7 dias. "
-            "Para monitoramento de prazos criticos, use um provider comercial "
+            "Para monitoramento de prazos críticos, use um provider comercial "
             "com webhook (Fase 3) ou acesse diretamente o portal do tribunal."
         ),
     }

--- a/src/mcp_juridico_brasil/movimentacoes/tools.py
+++ b/src/mcp_juridico_brasil/movimentacoes/tools.py
@@ -15,25 +15,25 @@ async def listar_movimentacoes(
     tribunal: str,
     limite: int = 20,
 ) -> dict[str, object]:
-    """Lista as movimentacoes mais recentes de um processo judicial.
+    """Lista as movimentações mais recentes de um processo judicial.
 
-    Retorna o historico de andamentos com codigo TPU, nome e data/hora,
+    Retorna o histórico de andamentos com código TPU, nome e data/hora,
     ordenado do mais recente para o mais antigo.
 
     Args:
-        numero_processo: Numero no formato CNJ.
-        tribunal: Sigla do tribunal (obrigatoria nesta tool para evitar
-                  varredura de todos os indices).
-        limite: Numero maximo de movimentacoes a retornar (padrao 20, max 50).
+        numero_processo: Número no formato CNJ.
+        tribunal: Sigla do tribunal (obrigatória nesta tool para evitar
+                  varredura de todos os índices).
+        limite: Número máximo de movimentações a retornar (padrão 20, max 50).
 
     Returns:
-        Lista de movimentacoes com metadados.
+        Lista de movimentações com metadados.
     """
     if not validar_numero_cnj(numero_processo):
         raise JuridicoValidationError(
             field="numero_processo",
             value=numero_processo,
-            reason="Formato invalido. Use o padrao CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO.",
+            reason="Formato inválido. Use o padrão CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO.",
         )
 
     limite = min(max(1, limite), 50)
@@ -48,7 +48,7 @@ async def listar_movimentacoes(
         "total_retornado": len(movs),
         "movimentacoes": [m.model_dump(mode="json") for m in movs],
         "nota": (
-            "Movimentacoes refletem o DataJud com possivel defasagem de T+1 a T+7 dias. "
+            "Movimentações refletem o DataJud com possível defasagem de T+1 a T+7 dias. "
             "Consulte o portal do tribunal para dados em tempo real."
         ),
     }

--- a/src/mcp_juridico_brasil/prazo/calendario.py
+++ b/src/mcp_juridico_brasil/prazo/calendario.py
@@ -1,33 +1,33 @@
-"""Calendario forense brasileiro para calculo de prazos processuais.
+"""Calendário forense brasileiro para cálculo de prazos processuais.
 
 Implementa as regras do CPC/2015:
-- Art. 219: prazos contados em dias uteis
-- Art. 224: termo inicial no primeiro dia util seguinte ao da intimacao/publicacao
-- Art. 220: suspensao de prazos durante recesso forense (20/dez a 20/jan)
+- Art. 219: prazos contados em dias úteis
+- Art. 224: termo inicial no primeiro dia útil seguinte ao da intimação/publicação
+- Art. 220: suspensão de prazos durante recesso forense (20/dez a 20/jan)
 
 Cobertura de feriados:
-- Feriados nacionais via workalendar (Brazil): Confraternizacao, Tiradentes,
-  Trabalho, Independencia, Aparecida, Finados, Proclamacao, Natal
-- Dia da Consciencia Negra (20/nov): feriado nacional desde 2024 (Lei 14.759/2023);
-  patch manual necessario pois o workalendar v17 nao inclui essa data
-- Sexta-feira Santa (feriado nacional reconhecido pelo STJ/TST, nao incluido
-  no workalendar Brasil por ser movel; calculado com python-dateutil)
+- Feriados nacionais via workalendar (Brazil): Confraternização, Tiradentes,
+  Trabalho, Independência, Aparecida, Finados, Proclamação, Natal
+- Dia da Consciência Negra (20/nov): feriado nacional desde 2024 (Lei 14.759/2023);
+  patch manual necessário pois o workalendar v17 não inclui essa data
+- Sexta-feira Santa (feriado nacional reconhecido pelo STJ/TST, não incluído
+  no workalendar Brasil por ser móvel; calculado com python-dateutil)
 - Feriados estaduais via workalendar subregions (BR-SP, BR-RJ, etc.)
   para as UFs mapeadas - ver UF_PARA_ISO abaixo
 
-Limitacoes documentadas (campo 'aviso' na tool):
-- Feriados municipais (ex: aniversario da cidade) NAO sao cobertos
-- Ponto facultativo de Carnaval (2a/3a-feira) NAO eh feriado legal; tribunais
-  podem ou nao suspender expediente - o advogado deve verificar o expediente
+Limitações documentadas (campo 'aviso' na tool):
+- Feriados municipais (ex: aniversário da cidade) NÃO são cobertos
+- Ponto facultativo de Carnaval (2a/3a-feira) NÃO é feriado legal; tribunais
+  podem ou não suspender expediente - o advogado deve verificar o expediente
   do tribunal
-- Corpus Christi (60 dias apos a Pascoa) e ponto facultativo federal e
-  suspenso na maioria dos tribunais, mas NAO tem status de feriado legal
-  nacional - o advogado deve verificar o expediente do tribunal especifico
-- Feriados estaduais de UFs sem subregion mapeada no workalendar sao tratados
+- Corpus Christi (60 dias após a Páscoa) é ponto facultativo federal e
+  suspenso na maioria dos tribunais, mas NÃO tem status de feriado legal
+  nacional - o advogado deve verificar o expediente do tribunal específico
+- Feriados estaduais de UFs sem subregion mapeada no workalendar são tratados
   como apenas nacionais
-- Feriados criados por legislacao estadual posterior a base de dados do
-  workalendar podem nao estar incluidos
-- Esta implementacao NAO substitui a consulta ao portal do tribunal
+- Feriados criados por legislação estadual posterior à base de dados do
+  workalendar podem não estar incluídos
+- Esta implementação NÃO substitui a consulta ao portal do tribunal
 """
 
 from __future__ import annotations
@@ -81,32 +81,32 @@ _RECESSO_FIM_DIA = 20
 
 @dataclass
 class ResultadoCalculo:
-    """Resultado estruturado do calculo de prazo processual."""
+    """Resultado estruturado do cálculo de prazo processual."""
 
     data_intimacao: datetime.date
-    """Data de intimacao/publicacao fornecida."""
+    """Data de intimação/publicação fornecida."""
     termo_inicial: datetime.date
-    """Primeiro dia util apos a intimacao (art. 224 CPC)."""
+    """Primeiro dia útil após a intimação (art. 224 CPC)."""
     data_final: datetime.date
-    """Data final do prazo (ultimo dia util contado)."""
+    """Data final do prazo (último dia útil contado)."""
     dias_uteis: int
-    """Quantidade de dias uteis do prazo."""
+    """Quantidade de dias úteis do prazo."""
     feriados_no_periodo: list[tuple[datetime.date, str]] = field(default_factory=list)
-    """Feriados/recessos que caíram no periodo e foram pulados."""
+    """Feriados/recessos que caíram no período e foram pulados."""
     dias_recesso: int = 0
-    """Quantidade de dias de recesso forense que afetaram o calculo."""
+    """Quantidade de dias de recesso forense que afetaram o cálculo."""
     uf: str | None = None
-    """UF considerada no calculo (influencia feriados estaduais)."""
+    """UF considerada no cálculo (influencia feriados estaduais)."""
     aviso: str = ""
-    """Aviso de limitacoes do calculo."""
+    """Aviso de limitações do cálculo."""
 
 
 class _CalendarioCache:
     """Cache de feriados por UF e ano, thread-safe via Lock.
 
     Uso interno: asyncio single-thread. O Lock garante corretude caso o
-    servidor seja chamado com concorrencia real em Fase 3+ (ex: multiplas
-    requisicoes HTTP simultaneas).
+    servidor seja chamado com concorrência real em Fase 3+ (ex: múltiplas
+    requisições HTTP simultâneas).
     """
 
     def __init__(self) -> None:
@@ -115,25 +115,25 @@ class _CalendarioCache:
         self._lock = threading.Lock()
 
     def _sexta_santa(self, ano: int) -> datetime.date:
-        """Calcula a Sexta-feira Santa (2 dias antes da Pascoa)."""
+        """Calcula a Sexta-feira Santa (2 dias antes da Páscoa)."""
         pascoa: datetime.date = easter(ano)
         return pascoa - datetime.timedelta(days=2)
 
     def _feriados_nacionais_base(self, ano: int) -> set[datetime.date]:
         """Feriados nacionais via workalendar + patches manuais.
 
-        Patches necessarios:
-        - Sexta-feira Santa: feriado movel nao incluido no workalendar Brasil
-        - Dia da Consciencia Negra (20/nov): feriado nacional desde 2024
-          (Lei 14.759/2023); workalendar v17 nao inclui essa data
+        Patches necessários:
+        - Sexta-feira Santa: feriado móvel não incluído no workalendar Brasil
+        - Dia da Consciência Negra (20/nov): feriado nacional desde 2024
+          (Lei 14.759/2023); workalendar v17 não inclui essa data
         """
         from workalendar.america import Brazil
 
         cal = Brazil()
         feriados = {d for d, _ in cal.holidays(ano)}
         feriados.add(self._sexta_santa(ano))
-        # Patch: 20/nov = Dia da Consciencia Negra (Lei 14.759/2023, vigente a
-        # partir de 2024). workalendar v17 nao inclui; patch manual necessario.
+        # Patch: 20/nov = Dia da Consciência Negra (Lei 14.759/2023, vigente a
+        # partir de 2024). workalendar v17 não inclui; patch manual necessário.
         if ano >= 2024:
             feriados.add(datetime.date(ano, 11, 20))
         return feriados
@@ -141,7 +141,7 @@ class _CalendarioCache:
     def _nomes_nacionais_base(self, ano: int) -> dict[datetime.date, str]:
         """Nomes dos feriados nacionais (inclui patches manuais).
 
-        Constroi o mapa date->nome uma unica vez por ano; chamadas subsequentes
+        Constrói o mapa date->nome uma única vez por ano; chamadas subsequentes
         devem usar get_nomes() que cacheia o resultado.
         """
         from workalendar.america import Brazil
@@ -150,7 +150,7 @@ class _CalendarioCache:
         nomes: dict[datetime.date, str] = {d: str(n) for d, n in cal.holidays(ano)}
         nomes[self._sexta_santa(ano)] = "Sexta-feira Santa"
         if ano >= 2024:
-            nomes[datetime.date(ano, 11, 20)] = "Dia da Consciencia Negra"
+            nomes[datetime.date(ano, 11, 20)] = "Dia da Consciência Negra"
         return nomes
 
     def _feriados_estaduais(self, uf: str, ano: int) -> set[datetime.date]:
@@ -164,7 +164,7 @@ class _CalendarioCache:
         if cal_class is None:
             return set()
         cal_uf = cal_class()
-        # feriados do estado inclui nacionais; pegamos so os extras
+        # feriados do estado inclui nacionais; pegamos só os extras
         nacionais = self._feriados_nacionais_base(ano)
         todos_uf = {d for d, _ in cal_uf.holidays(ano)}
         return todos_uf - nacionais
@@ -202,7 +202,7 @@ class _CalendarioCache:
         """Retorna mapa date->nome para o ano e UF dados (com cache).
 
         Evita instanciar Brazil() ou chamar holidays() repetidamente;
-        o resultado e calculado uma unica vez por (uf, ano).
+        o resultado é calculado uma única vez por (uf, ano).
         """
         chave = (uf.upper() if uf else None, ano)
         with self._lock:
@@ -228,7 +228,7 @@ def _em_recesso(data: datetime.date) -> bool:
 
 
 def _eh_dia_util_forense(data: datetime.date, feriados: set[datetime.date]) -> bool:
-    """Retorna True se a data eh dia util para fins de prazo processual.
+    """Retorna True se a data é dia útil para fins de prazo processual.
 
     Considera: fim de semana, feriados nacionais/estaduais e recesso forense.
     """
@@ -246,18 +246,18 @@ def calcular_prazo(
     dias_uteis: int,
     uf: str | None = None,
 ) -> ResultadoCalculo:
-    """Calcula o prazo processual em dias uteis a partir da data de intimacao.
+    """Calcula o prazo processual em dias úteis a partir da data de intimação.
 
     Regras aplicadas:
-    - O prazo comeca a correr no primeiro dia util SEGUINTE a data de intimacao
-      (art. 224 CPC). A data de intimacao em si nao entra na contagem.
-    - Sabados, domingos, feriados nacionais, feriados estaduais (se UF fornecida)
-      e dias de recesso forense (20/dez a 20/jan) sao ignorados.
-    - O prazo termina no ultimo dia util contado.
+    - O prazo começa a correr no primeiro dia útil SEGUINTE à data de intimação
+      (art. 224 CPC). A data de intimação em si não entra na contagem.
+    - Sábados, domingos, feriados nacionais, feriados estaduais (se UF fornecida)
+      e dias de recesso forense (20/dez a 20/jan) são ignorados.
+    - O prazo termina no último dia útil contado.
 
     Args:
-        data_intimacao: Data de intimacao/publicacao (dia 0, nao entra na contagem).
-        dias_uteis: Quantidade de dias uteis do prazo (ex: 15 para contestacao).
+        data_intimacao: Data de intimação/publicação (dia 0, não entra na contagem).
+        dias_uteis: Quantidade de dias úteis do prazo (ex: 15 para contestação).
         uf: Sigla da UF para incluir feriados estaduais (ex: 'SP', 'RJ').
             Se omitida, usa apenas feriados nacionais.
 
@@ -267,7 +267,7 @@ def calcular_prazo(
     if dias_uteis <= 0:
         raise ValueError(f"dias_uteis deve ser positivo, recebeu {dias_uteis}")
 
-    # Pre-carrega feriados por ano conforme necessario
+    # Pré-carrega feriados por ano conforme necessário
     feriados_por_ano: dict[int, set[datetime.date]] = {}
 
     def _get_feriados(ano: int) -> set[datetime.date]:
@@ -278,13 +278,13 @@ def calcular_prazo(
     def _util(data: datetime.date) -> bool:
         return _eh_dia_util_forense(data, _get_feriados(data.year))
 
-    # Art. 224: termo inicial = primeiro dia util APOS a intimacao
+    # Art. 224: termo inicial = primeiro dia útil APÓS a intimação
     candidato = data_intimacao + datetime.timedelta(days=1)
     while not _util(candidato):
         candidato += datetime.timedelta(days=1)
     termo_inicial = candidato
 
-    # Contar dias_uteis a partir do termo_inicial (inclusive)
+    # Contar dias_uteis a partir do termo_inicial (inclusivo)
     dias_contados = 0
     cursor = termo_inicial
     data_final = termo_inicial
@@ -295,10 +295,10 @@ def calcular_prazo(
             data_final = cursor
         cursor += datetime.timedelta(days=1)
 
-    # Coletar feriados/recessos que afetaram o calculo.
-    # O scan vai de (data_intimacao + 1) ate data_final para capturar tambem
-    # feriados que atrasaram o proprio termo inicial (ex: Tiradentes forcou
-    # o termo a avancar de 21/abr para 22/abr).
+    # Coletar feriados/recessos que afetaram o cálculo.
+    # O scan vai de (data_intimacao + 1) até data_final para capturar também
+    # feriados que atrasaram o próprio termo inicial (ex: Tiradentes forçou
+    # o termo a avançar de 21/abr para 22/abr).
     feriados_periodo: list[tuple[datetime.date, str]] = []
     dias_recesso = 0
     dia_scan = data_intimacao + datetime.timedelta(days=1)
@@ -317,20 +317,20 @@ def calcular_prazo(
         iso = UF_PARA_ISO.get(uf.upper())
         if iso is None:
             uf_aviso = (
-                f" ATENCAO: UF '{uf}' nao tem feriados estaduais mapeados; "
+                f" ATENÇÃO: UF '{uf}' não tem feriados estaduais mapeados; "
                 "apenas feriados nacionais foram considerados."
             )
 
     aviso = (
-        "AVISO LEGAL: Este calculo e uma estimativa tecnica baseada em feriados nacionais"
+        "AVISO LEGAL: Este cálculo é uma estimativa técnica baseada em feriados nacionais"
         + (f" e estaduais ({uf})" if uf else "")
         + " e no recesso forense (art. 220 CPC). "
-        "NAO considera: feriados municipais, pontos facultativos de Carnaval, "
+        "NÃO considera: feriados municipais, pontos facultativos de Carnaval, "
         "Corpus Christi (ponto facultativo federal suspenso na maioria dos tribunais, "
         "mas sem status de feriado legal nacional), "
-        "suspensoes extraordinarias (pandemias, catastrofes), prazos proprios de "
-        "cada tribunal ou portarias de antecipacao de recesso. "
-        "O advogado responsavel DEVE verificar o prazo efetivo no portal do tribunal. "
+        "suspensões extraordinárias (pandemias, catástrofes), prazos próprios de "
+        "cada tribunal ou portarias de antecipação de recesso. "
+        "O advogado responsável DEVE verificar o prazo efetivo no portal do tribunal. "
         "(OAB Rec. 001/2024)" + uf_aviso
     )
 
@@ -347,10 +347,10 @@ def calcular_prazo(
 
 
 def _nome_feriado(data: datetime.date, uf: str | None) -> str:
-    """Retorna o nome do feriado para uma data (melhor esforco).
+    """Retorna o nome do feriado para uma data (melhor esforço).
 
-    Usa o cache do modulo para evitar instanciar Brazil() e chamar
-    holidays() repetidamente. O mapa date->nome e calculado uma unica
+    Usa o cache do módulo para evitar instanciar Brazil() e chamar
+    holidays() repetidamente. O mapa date->nome é calculado uma única
     vez por (uf, ano) e reutilizado em chamadas subsequentes.
     """
     nomes = _cache.get_nomes(uf, data.year)

--- a/src/mcp_juridico_brasil/prazo/tools.py
+++ b/src/mcp_juridico_brasil/prazo/tools.py
@@ -1,18 +1,18 @@
 """Tool MCP: calcular_proximo_prazo.
 
-Fase 2: calculo de prazos processuais em dias uteis com calendario forense.
+Fase 2: cálculo de prazos processuais em dias úteis com calendário forense.
 
 Regras implementadas:
-- Art. 219 CPC: prazos contados em dias uteis
-- Art. 224 CPC: termo inicial no primeiro dia util apos a intimacao/publicacao
+- Art. 219 CPC: prazos contados em dias úteis
+- Art. 224 CPC: termo inicial no primeiro dia útil após a intimação/publicação
 - Art. 220 CPC: recesso forense (20/dez a 20/jan) suspende a contagem
 - Feriados nacionais via workalendar + Sexta-feira Santa
-- Feriados estaduais via workalendar subregions (parametro uf opcional)
+- Feriados estaduais via workalendar subregions (parâmetro uf opcional)
 
-IMPORTANTE: Este calculo e uma estimativa tecnica de apoio ao advogado.
-Nao substitui a verificacao no portal do tribunal nem a analise do profissional
-habilitado. Feriados municipais, pontos facultativos e suspensoes extraordinarias
-NAO sao automaticamente considerados.
+IMPORTANTE: Este cálculo é uma estimativa técnica de apoio ao advogado.
+Não substitui a verificação no portal do tribunal nem a análise do profissional
+habilitado. Feriados municipais, pontos facultativos e suspensões extraordinárias
+NÃO são automaticamente considerados.
 """
 
 from __future__ import annotations
@@ -56,32 +56,32 @@ async def calcular_proximo_prazo(
     uf: str | None = None,
     data_intimacao_iso: str | None = None,
 ) -> dict[str, object]:
-    """Calcula o proximo prazo processual em dias uteis com calendario forense.
+    """Calcula o próximo prazo processual em dias úteis com calendário forense.
 
-    Implementa art. 219 (dias uteis), art. 224 (termo inicial no dia seguinte)
-    e art. 220 CPC (suspensao no recesso forense 20/dez a 20/jan).
+    Implementa art. 219 (dias úteis), art. 224 (termo inicial no dia seguinte)
+    e art. 220 CPC (suspensão no recesso forense 20/dez a 20/jan).
 
     Args:
-        numero_processo: Numero no formato CNJ (NNNNNNN-DD.AAAA.J.TT.OOOO).
+        numero_processo: Número no formato CNJ (NNNNNNN-DD.AAAA.J.TT.OOOO).
         tribunal: Sigla do tribunal (ex: 'TJSP', 'TRF1').
         tipo_ato: Tipo do ato processual para selecionar prazo CPC
                   (ex: 'Contestacao', 'Embargos de Declaracao').
-                  Se omitido, usa prazo padrao de 15 dias uteis.
-        uf: Sigla da UF para incluir feriados estaduais no calculo
+                  Se omitido, usa prazo padrão de 15 dias úteis.
+        uf: Sigla da UF para incluir feriados estaduais no cálculo
             (ex: 'SP', 'RJ', 'MG'). Se omitida, usa apenas feriados nacionais.
-        data_intimacao_iso: Data de intimacao/publicacao em ISO 8601
+        data_intimacao_iso: Data de intimação/publicação em ISO 8601
                             (ex: '2025-01-15'). Se omitida, usa a data da
-                            ultima movimentacao disponivel no DataJud.
+                            última movimentação disponível no DataJud.
 
     Returns:
-        Dicionario com termo_inicial, data_final, dias_uteis, feriados
-        que afetaram o calculo e campo 'aviso' com limitacoes.
+        Dicionário com termo_inicial, data_final, dias_uteis, feriados
+        que afetaram o cálculo e campo 'aviso' com limitações.
     """
     if not validar_numero_cnj(numero_processo):
         raise JuridicoValidationError(
             field="numero_processo",
             value=numero_processo,
-            reason="Formato invalido. Use o padrao CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO.",
+            reason="Formato inválido. Use o padrão CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO.",
         )
 
     if uf is not None and uf.upper() not in UF_PARA_ISO:
@@ -89,7 +89,7 @@ async def calcular_proximo_prazo(
             field="uf",
             value=uf,
             reason=(
-                f"UF '{uf}' nao reconhecida. Use sigla de 2 letras (ex: 'SP', 'RJ', 'MG'). "
+                f"UF '{uf}' não reconhecida. Use sigla de 2 letras (ex: 'SP', 'RJ', 'MG'). "
                 f"UFs suportadas: {', '.join(sorted(UF_PARA_ISO.keys()))}"
             ),
         )
@@ -99,13 +99,13 @@ async def calcular_proximo_prazo(
     if data_intimacao_iso is not None:
         try:
             data_intimacao_input = datetime.date.fromisoformat(
-                data_intimacao_iso[:10]  # aceita datetime completo, usa so a data
+                data_intimacao_iso[:10]  # aceita datetime completo, usa só a data
             )
         except ValueError as exc:
             raise JuridicoValidationError(
                 field="data_intimacao_iso",
                 value=data_intimacao_iso,
-                reason="Data invalida. Use formato ISO 8601: YYYY-MM-DD ou YYYY-MM-DDTHH:MM:SS",
+                reason="Data inválida. Use formato ISO 8601: YYYY-MM-DD ou YYYY-MM-DDTHH:MM:SS",
             ) from exc
 
     numero_normalizado = normalizar_numero_cnj(numero_processo)
@@ -131,10 +131,10 @@ async def calcular_proximo_prazo(
                 "numero_processo": numero_normalizado,
                 "tribunal": tribunal,
                 "prazo_estimado": None,
-                "motivo": "Nenhuma movimentacao disponivel no DataJud para calcular prazo.",
+                "motivo": "Nenhuma movimentação disponível no DataJud para calcular prazo.",
                 "aviso": (
-                    "AVISO: Nao foi possivel calcular o prazo pois o processo nao "
-                    "possui movimentacoes registradas no DataJud. Verifique o portal "
+                    "AVISO: Não foi possível calcular o prazo pois o processo não "
+                    "possui movimentações registradas no DataJud. Verifique o portal "
                     "do tribunal ou forneça data_intimacao_iso manualmente."
                 ),
             }
@@ -185,8 +185,8 @@ async def calcular_proximo_prazo(
         "limitacao": (
             "Fase 2: feriados nacionais e estaduais cobertos. "
             "Feriados municipais, pontos facultativos (ex: Carnaval) e "
-            "suspensoes extraordinarias NAO sao considerados automaticamente. "
-            "Fase 3+ ampliara a cobertura com feeds de expediente por tribunal."
+            "suspensões extraordinárias NÃO são considerados automaticamente. "
+            "Fase 3+ ampliará a cobertura com feeds de expediente por tribunal."
         ),
     }
 

--- a/src/mcp_juridico_brasil/processo/tools.py
+++ b/src/mcp_juridico_brasil/processo/tools.py
@@ -1,9 +1,9 @@
 """Tool MCP: buscar_processo_por_numero.
 
-DISCLAIMER OBRIGATORIO (OAB Rec. 001/2024 + Provimento 205/2021):
-Esta ferramenta e destinada exclusivamente ao uso por advogados e profissionais
-do direito para acompanhamento de processos de seus clientes. Nao constitui
-consultoria juridica. A analise final e a orientacao ao cliente sao de
+DISCLAIMER OBRIGATÓRIO (OAB Rec. 001/2024 + Provimento 205/2021):
+Esta ferramenta é destinada exclusivamente ao uso por advogados e profissionais
+do direito para acompanhamento de processos de seus clientes. Não constitui
+consultoria jurídica. A análise final e a orientação ao cliente são de
 responsabilidade exclusiva do advogado habilitado.
 """
 
@@ -22,9 +22,9 @@ logger = get_logger(__name__)
 _provider = DataJudProvider()
 
 _DISCLAIMER = (
-    "AVISO: Esta informacao e fornecida para uso exclusivo do advogado responsavel. "
-    "Nao constitui consultoria juridica. Verifique sempre os dados diretamente no "
-    "portal do tribunal antes de tomar qualquer decisao processual."
+    "AVISO: Esta informação é fornecida para uso exclusivo do advogado responsável. "
+    "Não constitui consultoria jurídica. Verifique sempre os dados diretamente no "
+    "portal do tribunal antes de tomar qualquer decisão processual."
 )
 
 
@@ -32,36 +32,36 @@ async def buscar_processo_por_numero(
     numero_processo: str,
     tribunal: str | None = None,
 ) -> dict[str, object]:
-    """Busca os dados de um processo judicial pelo numero CNJ.
+    """Busca os dados de um processo judicial pelo número CNJ.
 
-    Consulta a API publica DataJud (CNJ) e retorna metadados do processo,
-    classe, assuntos, orgao julgador, partes e historico de movimentacoes.
+    Consulta a API pública DataJud (CNJ) e retorna metadados do processo,
+    classe, assuntos, órgão julgador, partes e histórico de movimentações.
 
     Cobertura: 91 tribunais (STF, STJ, TST, TSE, STM, TRF1-6, TRTs, TJs
     estaduais, TREs e militares estaduais).
 
     Args:
-        numero_processo: Numero no formato CNJ (ex: '0001234-56.2023.8.26.0100')
-                         ou sem formatacao (20 digitos).
+        numero_processo: Número no formato CNJ (ex: '0001234-56.2023.8.26.0100')
+                         ou sem formatação (20 dígitos).
         tribunal: Sigla do tribunal (ex: 'TJSP', 'TRF4', 'STJ'). Se omitida,
                   o sistema tenta localizar o processo em todos os tribunais
-                  (operacao mais lenta).
+                  (operação mais lenta).
 
     Returns:
-        Dicionario com dados do processo e aviso de responsabilidade.
+        Dicionário com dados do processo e aviso de responsabilidade.
 
     Raises:
-        JuridicoValidationError: Numero CNJ invalido.
-        JuridicoSigiloError: Processo em segredo de justica.
-        JuridicoNotFoundError: Processo nao localizado.
+        JuridicoValidationError: Número CNJ inválido.
+        JuridicoSigiloError: Processo em segredo de justiça.
+        JuridicoNotFoundError: Processo não localizado.
     """
     if not validar_numero_cnj(numero_processo):
         raise JuridicoValidationError(
             field="numero_processo",
             value=numero_processo,
             reason=(
-                "Formato invalido. Use o padrao CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO "
-                "ou os 20 digitos sem formatacao."
+                "Formato inválido. Use o padrão CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO "
+                "ou os 20 dígitos sem formatação."
             ),
         )
 
@@ -76,7 +76,7 @@ async def buscar_processo_por_numero(
         "fonte": "DataJud CNJ (API Publica - Portaria CNJ 160/2020)",
         "nota_defasagem": (
             "Os dados refletem o estado registrado no DataJud, que pode ter "
-            "atraso de horas a dias em relacao ao portal do tribunal de origem."
+            "atraso de horas a dias em relação ao portal do tribunal de origem."
         ),
     }
 

--- a/src/mcp_juridico_brasil/resumo/tools.py
+++ b/src/mcp_juridico_brasil/resumo/tools.py
@@ -1,12 +1,12 @@
 """Tool MCP: resumir_andamento.
 
 Gera um resumo em linguagem natural do andamento processual com base
-nas movimentacoes do DataJud. O resumo e produzido pelo proprio LLM
-que invoca esta tool - o MCP retorna os dados estruturados e a instrucao
-de resumo; nao chama um LLM externo (sem dependencia de OpenAI/Anthropic).
+nas movimentações do DataJud. O resumo é produzido pelo próprio LLM
+que invoca esta tool - o MCP retorna os dados estruturados e a instrução
+de resumo; não chama um LLM externo (sem dependência de OpenAI/Anthropic).
 
-DISCLAIMER: O resumo e gerado a partir de metadados publicos do DataJud.
-Nao substitui a leitura integral dos autos pelo advogado responsavel.
+DISCLAIMER: O resumo é gerado a partir de metadados públicos do DataJud.
+Não substitui a leitura integral dos autos pelo advogado responsável.
 """
 
 from __future__ import annotations
@@ -20,15 +20,15 @@ _provider = DataJudProvider()
 
 _INSTRUCAO_RESUMO = """
 Com base nos dados estruturados do processo acima, produza um resumo objetivo
-em linguagem juridica acessivel contendo:
-1. Identificacao do processo (tribunal, classe, assunto principal, orgao julgador).
-2. Status atual (ultima movimentacao e seu significado pratico).
-3. Historico resumido das ultimas movimentacoes em ordem cronologica.
-4. Pontos de atencao que o advogado deve verificar no portal do tribunal.
+em linguagem jurídica acessível contendo:
+1. Identificação do processo (tribunal, classe, assunto principal, órgão julgador).
+2. Status atual (última movimentação e seu significado prático).
+3. Histórico resumido das últimas movimentações em ordem cronológica.
+4. Pontos de atenção que o advogado deve verificar no portal do tribunal.
 
-Mantenha tom tecnico-juridico. Nao emita opiniao sobre o merito da causa.
-Nao faca previsoes de resultado. Se algum dado estiver ausente, indique
-'nao disponivel via DataJud' e oriente o advogado a consultar o portal do tribunal.
+Mantenha tom técnico-jurídico. Não emita opinião sobre o mérito da causa.
+Não faça previsões de resultado. Se algum dado estiver ausente, indique
+'não disponível via DataJud' e oriente o advogado a consultar o portal do tribunal.
 """
 
 
@@ -36,24 +36,24 @@ async def resumir_andamento(
     numero_processo: str,
     tribunal: str | None = None,
 ) -> dict[str, object]:
-    """Retorna dados estruturados de um processo para geracao de resumo pelo LLM.
+    """Retorna dados estruturados de um processo para geração de resumo pelo LLM.
 
     Esta tool busca o processo no DataJud e devolve os dados formatados
-    junto com instrucoes para que o modelo gere o resumo em linguagem natural.
-    O processamento semantico (resumo) fica no modelo, nao no MCP.
+    junto com instruções para que o modelo gere o resumo em linguagem natural.
+    O processamento semântico (resumo) fica no modelo, não no MCP.
 
     Args:
-        numero_processo: Numero no formato CNJ.
+        numero_processo: Número no formato CNJ.
         tribunal: Sigla do tribunal. Se omitida, o sistema pesquisa em todos.
 
     Returns:
-        Dados do processo + instrucao de resumo para o modelo.
+        Dados do processo + instrução de resumo para o modelo.
     """
     if not validar_numero_cnj(numero_processo):
         raise JuridicoValidationError(
             field="numero_processo",
             value=numero_processo,
-            reason="Formato invalido. Use o padrao CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO.",
+            reason="Formato inválido. Use o padrão CNJ: NNNNNNN-DD.AAAA.J.TT.OOOO.",
         )
 
     numero_normalizado = normalizar_numero_cnj(numero_processo)
@@ -65,12 +65,12 @@ async def resumir_andamento(
         "dados_processo": processo.model_dump(mode="json"),
         "instrucao_resumo": _INSTRUCAO_RESUMO.strip(),
         "aviso": (
-            "AVISO LEGAL: Este resumo e gerado a partir de metadados publicos "
-            "do DataJud CNJ com possivel defasagem. Nao constitui consultoria juridica "
-            "nem substitui a leitura integral dos autos pelo advogado responsavel. "
-            "Fundamento: OAB Recomendacao 001/2024."
+            "AVISO LEGAL: Este resumo é gerado a partir de metadados públicos "
+            "do DataJud CNJ com possível defasagem. Não constitui consultoria jurídica "
+            "nem substitui a leitura integral dos autos pelo advogado responsável. "
+            "Fundamento: OAB Recomendação 001/2024."
         ),
-        "fonte": "DataJud CNJ (API Publica)",
+        "fonte": "DataJud CNJ (API Pública)",
     }
 
 

--- a/src/mcp_juridico_brasil/server.py
+++ b/src/mcp_juridico_brasil/server.py
@@ -1,22 +1,22 @@
-"""Servidor MCP Juridico Brasil.
+"""Servidor MCP Jurídico Brasil.
 
-Registra tools e resources no FastMCP e expoe o servidor via stdio (padrao)
+Registra tools e resources no FastMCP e expõe o servidor via stdio (padrão)
 ou HTTP streamable (Smithery/Docker).
 
 Tools expostas (Fase 2):
-- buscar_processo_por_numero  : consulta completa por numero CNJ
-- listar_movimentacoes        : historico de andamentos
-- resumir_andamento           : dados + instrucao de resumo para o LLM
-- monitorar_processo          : verifica atualizacao desde data (polling)
-- calcular_proximo_prazo      : calculo em dias uteis com calendario forense
-- listar_processos_monitorados: lista processos com snapshot em memoria
+- buscar_processo_por_numero  : consulta completa por número CNJ
+- listar_movimentacoes        : histórico de andamentos
+- resumir_andamento           : dados + instrução de resumo para o LLM
+- monitorar_processo          : verifica atualização desde data (polling)
+- calcular_proximo_prazo      : cálculo em dias úteis com calendário forense
+- listar_processos_monitorados: lista processos com snapshot em memória
 - listar_tribunais            : lista de siglas suportadas
 
 Resources expostos (Fase 2):
-- processo://{numero_processo}/snapshot  : ultimo snapshot do processo
+- processo://{numero_processo}/snapshot  : último snapshot do processo
 
-Fases futuras adicionarao tools de webhook push (Fase 3) e
-intimacoes DJe (Fase 4) sem quebrar a interface existente.
+Fases futuras adicionarão tools de webhook push (Fase 3) e
+intimações DJe (Fase 4) sem quebrar a interface existente.
 """
 
 from __future__ import annotations
@@ -44,12 +44,12 @@ app = fastmcp.FastMCP(
     version="0.2.0",
     instructions=(
         "Ferramentas de acompanhamento de processos judiciais brasileiros via DataJud CNJ. "
-        "Cobertura de 91 tribunais. Dados com possivel defasagem de T+1 a T+7 dias. "
-        "Fase 2: calculo de prazos em dias uteis (art. 219/220/224 CPC) com calendario "
+        "Cobertura de 91 tribunais. Dados com possível defasagem de T+1 a T+7 dias. "
+        "Fase 2: cálculo de prazos em dias úteis (art. 219/220/224 CPC) com calendário "
         "forense nacional e estadual. "
-        "AVISO: Estas ferramentas sao destinadas a advogados e profissionais do direito. "
-        "Nao constituem consultoria juridica. A analise final e responsabilidade do "
-        "advogado habilitado (OAB Recomendacao 001/2024)."
+        "AVISO: Estas ferramentas são destinadas a advogados e profissionais do direito. "
+        "Não constituem consultoria jurídica. A análise final é responsabilidade do "
+        "advogado habilitado (OAB Recomendação 001/2024)."
     ),
 )
 
@@ -68,7 +68,7 @@ app.tool()(calcular_proximo_prazo)
 async def listar_tribunais() -> dict[str, object]:
     """Lista todos os tribunais suportados pelo MCP (91 ao total).
 
-    Retorna siglas que podem ser usadas no parametro 'tribunal' das demais tools.
+    Retorna siglas que podem ser usadas no parâmetro 'tribunal' das demais tools.
     """
     tribunais = _listar_tribunais()
     return {
@@ -76,29 +76,29 @@ async def listar_tribunais() -> dict[str, object]:
         "tribunais": tribunais,
         "nota": (
             "Siglas baseadas no cadastro DataJud CNJ (Portaria 160/2020). "
-            "Use exatamente estas siglas no parametro 'tribunal' das demais tools."
+            "Use exatamente estas siglas no parâmetro 'tribunal' das demais tools."
         ),
     }
 
 
 @app.tool()
 async def listar_processos_monitorados() -> dict[str, object]:
-    """Lista processos com snapshot em memoria na sessao atual.
+    """Lista processos com snapshot em memória na sessão atual.
 
-    Retorna os numeros de processos que tiveram snapshot salvo nesta sessao.
+    Retorna os números de processos que tiveram snapshot salvo nesta sessão.
     Use o resource processo://{numero}/snapshot para ler os dados completos.
 
     Returns:
-        Dicionario com lista de numeros e total.
+        Dicionário com lista de números e total.
     """
     numeros = _listar_monitorados()
     return {
         "total": len(numeros),
         "processos": numeros,
         "nota": (
-            "Snapshots em memoria da sessao MCP atual. "
-            "O estado e perdido ao reiniciar o servidor. "
-            "Configure JURIDICO_SNAPSHOT_DIR para persistencia em arquivo."
+            "Snapshots em memória da sessão MCP atual. "
+            "O estado é perdido ao reiniciar o servidor. "
+            "Configure JURIDICO_SNAPSHOT_DIR para persistência em arquivo."
         ),
     }
 
@@ -112,14 +112,14 @@ async def listar_processos_monitorados() -> dict[str, object]:
 async def resource_snapshot_processo(numero_processo: str) -> str:
     """Snapshot mais recente de um processo monitorado.
 
-    Retorna os dados capturados na ultima chamada a monitorar_processo
-    ou buscar_processo_por_numero para este numero de processo.
+    Retorna os dados capturados na última chamada a monitorar_processo
+    ou buscar_processo_por_numero para este número de processo.
 
     Args:
-        numero_processo: Numero CNJ do processo (normalizado, sem formatacao).
+        numero_processo: Número CNJ do processo (normalizado, sem formatação).
 
     Returns:
-        JSON com dados do snapshot ou mensagem de ausencia.
+        JSON com dados do snapshot ou mensagem de ausência.
     """
     snapshot = obter_snapshot(numero_processo)
     if snapshot is None:
@@ -128,7 +128,7 @@ async def resource_snapshot_processo(numero_processo: str) -> str:
                 "encontrado": False,
                 "numero_processo": numero_processo,
                 "mensagem": (
-                    "Nenhum snapshot disponivel para este processo. "
+                    "Nenhum snapshot disponível para este processo. "
                     "Chame buscar_processo_por_numero ou monitorar_processo primeiro."
                 ),
             },

--- a/src/mcp_juridico_brasil/shared/schemas.py
+++ b/src/mcp_juridico_brasil/shared/schemas.py
@@ -1,9 +1,9 @@
-"""Schemas Pydantic compartilhados entre os modulos do MCP Juridico Brasil.
+"""Schemas Pydantic compartilhados entre os módulos do MCP Jurídico Brasil.
 
-NOTA LGPD: Estes schemas nao persistem CPF/CNPJ de partes nem dados sensiveis
-(saude, orientacao sexual, origem etnica) mesmo quando presentes nos autos.
-Campos de identificacao de partes adversas sao retornados somente para o
-advogado autenticado cujo processo esta sendo monitorado.
+NOTA LGPD: Estes schemas não persistem CPF/CNPJ de partes nem dados sensíveis
+(saúde, orientação sexual, origem étnica) mesmo quando presentes nos autos.
+Campos de identificação de partes adversas são retornados somente para o
+advogado autenticado cujo processo está sendo monitorado.
 """
 
 from __future__ import annotations
@@ -23,12 +23,12 @@ class OrgaoJulgador(BaseModel):
 class Parte(BaseModel):
     """Parte processual.
 
-    LGPD: O campo 'nome' e retornado como presente na API publica DataJud.
-    CPF/CNPJ nao e indexado pela API publica por razoes de LGPD.
+    LGPD: O campo 'nome' é retornado como presente na API pública DataJud.
+    CPF/CNPJ não é indexado pela API pública por razões de LGPD.
     """
 
     nome: str
-    tipo: str  # ex.: "Advogado", "Autor", "Reu", "Interessado"
+    tipo: str  # ex.: "Advogado", "Autor", "Réu", "Interessado"
     polo: str | None = None  # "ativo", "passivo", "outros"
 
 
@@ -46,10 +46,10 @@ class Assunto(BaseModel):
 
 
 class Processo(BaseModel):
-    """Representacao de um processo judicial.
+    """Representação de um processo judicial.
 
-    nivel_sigilo == 0 indica processo publico.
-    nivel_sigilo > 0 NUNCA deve ser armazenado ou exibido sem autorizacao judicial.
+    nivel_sigilo == 0 indica processo público.
+    nivel_sigilo > 0 NUNCA deve ser armazenado ou exibido sem autorização judicial.
     """
 
     numero_processo: str
@@ -64,7 +64,7 @@ class Processo(BaseModel):
     orgao_julgador: OrgaoJulgador | None = None
     partes: list[Parte] = Field(default_factory=list)
     movimentacoes: list[Movimentacao] = Field(default_factory=list)
-    formato: str | None = None  # "Fisico" ou "Eletronico"
+    formato: str | None = None  # "Físico" ou "Eletrônico"
     sistema: str | None = None  # "PJe", "eSAJ", "eProc", etc.
 
     @property


### PR DESCRIPTION
## Resumo

Varredura retroativa de acentuação pt-BR no repositório. Arquivos criados antes do hook pt-BR tinham palavras sem acento em docstrings, comentários e mensagens de erro/log.

## Arquivos corrigidos (17)

**Documentação (2):**
- `docs/PLANO-E2E.md` - ~40 ocorrências (versão, cálculo, módulo, etc.)
- `docs/PESQUISA.md` - ~35 ocorrências (consolidação, autenticação, etc.)

**Código Python - apenas texto, sem alteração de lógica (15):**
- `_core/config.py`, `_core/errors.py`, `_core/http.py`, `_core/logging.py`
- `datajud/client.py`, `datajud/provider.py`
- `shared/schemas.py`
- `server.py`
- `processo/tools.py`, `movimentacoes/tools.py`
- `monitoramento/tools.py`, `monitoramento/store.py`
- `prazo/tools.py`, `prazo/calendario.py`
- `resumo/tools.py`

## Verificações

- `uv run ruff check .` - ok (sem erros)
- `uv run pytest -q` - 93 passed, 0 failed

## Escopo

Somente texto em docstrings, comentários e strings de mensagem (erro/log/aviso). Identificadores, nomes de variáveis e termos técnicos em inglês foram preservados intactos.