### PR TITLE
feat: provider comercial, webhook e fallback (Fase 3)

### DIFF
--- a/src/mcp_juridico_brasil/comercial/__init__.py
+++ b/src/mcp_juridico_brasil/comercial/__init__.py
@@ -1,0 +1,30 @@
+"""Modulo de providers comerciais para o MCP Juridico Brasil.
+
+Providers disponiveis:
+- JuditProvider  - judit.io (B2B, webhook nativo, 100% tribunais declarado)
+- EscavadorProvider - escavador.com/business/api (SDK Python, CPF/CNPJ/OAB)
+- TrackJudProvider - trackjud.com.br (por consulta, bom para MVP/prototipo)
+
+Todos os providers implementam ProcessoProvider e podem ser selecionados via
+variavel de ambiente JURIDICO_PROVIDER (valores: datajud | judit | escavador | trackjud).
+
+A integracao real de cada provider comercial fica pronta para plugar a chave
+via JURIDICO_PROVIDER_API_KEY - nenhuma credencial e hardcoded aqui.
+"""
+
+from mcp_juridico_brasil.comercial.providers import (
+    EscavadorProvider,
+    JuditProvider,
+    TrackJudProvider,
+)
+from mcp_juridico_brasil.comercial.registry import selecionar_provider
+from mcp_juridico_brasil.comercial.webhook import WebhookPayload, processar_webhook
+
+__all__ = [
+    "EscavadorProvider",
+    "JuditProvider",
+    "TrackJudProvider",
+    "WebhookPayload",
+    "processar_webhook",
+    "selecionar_provider",
+]

--- a/src/mcp_juridico_brasil/comercial/providers.py
+++ b/src/mcp_juridico_brasil/comercial/providers.py
@@ -1,0 +1,652 @@
+"""Providers comerciais mock-ready para o MCP Juridico Brasil.
+
+Cada provider implementa ProcessoProvider usando a documentacao publica
+da API correspondente. A autenticacao e feita exclusivamente via variavel
+de ambiente JURIDICO_PROVIDER_API_KEY - nunca hardcoded.
+
+ATENCAO SEGURANCA: As URLs base e paths de cada provider sao constantes
+fixadas no codigo. A construcao de URL nao interpola dados externos para
+evitar SSRF (Server-Side Request Forgery). Parametros de busca vao sempre
+como query params ou corpo JSON, jamais interpolados na URL base.
+
+NOTA DE INTEGRACAO: Cada provider tem marcacao explicita dos pontos que
+exigem validacao com credencial real antes de ir para producao. A estrutura
+de request/response segue a documentacao publica disponivel em junho de 2026.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from mcp_juridico_brasil._core.errors import (
+    JuridicoAPIError,
+    JuridicoNotFoundError,
+    JuridicoSigiloError,
+)
+from mcp_juridico_brasil._core.logging import get_logger
+from mcp_juridico_brasil.datajud.provider import ProcessoProvider
+from mcp_juridico_brasil.shared.schemas import Assunto, Movimentacao, OrgaoJulgador, Parte, Processo
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constantes de URL (fixas - sem interpolacao de dados externos)
+# ---------------------------------------------------------------------------
+
+_JUDIT_BASE_URL = "https://api.judit.io"
+_ESCAVADOR_BASE_URL = "https://api.escavador.com"
+_TRACKJUD_BASE_URL = "https://api.trackjud.com.br"
+
+# Tempo maximo de espera por resposta dos providers (segundos)
+_TIMEOUT_COMERCIAL = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers de autenticacao
+# ---------------------------------------------------------------------------
+
+
+def _exigir_api_key(provider_nome: str) -> str:
+    """Retorna JURIDICO_PROVIDER_API_KEY ou lanca erro informativo.
+
+    SEGURANCA: Chaves de API nunca tem valor default. O erro orienta o
+    operador a configurar a variavel de ambiente correta.
+    """
+    api_key = os.environ.get("JURIDICO_PROVIDER_API_KEY", "").strip()
+    if not api_key:
+        raise JuridicoAPIError(
+            source=provider_nome,
+            reason=(
+                "Chave de API ausente. Configure JURIDICO_PROVIDER_API_KEY "
+                f"com sua chave do {provider_nome}."
+            ),
+        )
+    return api_key
+
+
+# ---------------------------------------------------------------------------
+# Parser generico de resposta
+# ---------------------------------------------------------------------------
+
+
+def _iso_ou_none(valor: str | None) -> datetime | None:
+    """Converte string ISO 8601 para datetime com fuso UTC ou retorna None."""
+    if not valor:
+        return None
+    try:
+        dt = datetime.fromisoformat(valor.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# JuditProvider
+# ---------------------------------------------------------------------------
+
+
+class JuditProvider(ProcessoProvider):
+    """Provider baseado na API judit.io.
+
+    INTEGRACAO PENDENTE DE VALIDACAO COM CREDENCIAL REAL.
+    Esta implementacao segue a documentacao publica do judit.io (junho de 2026).
+    Antes de usar em producao, validar:
+    - Formato exato do header de autenticacao (Bearer vs Api-Key)
+    - Schema da resposta de buscar_processo (campos podem diferir)
+    - Endpoint de listar movimentacoes (pode ser separado ou embutido no processo)
+    - Rate limits e politica de retry da API Judit
+
+    Referencia: https://judit.io/planos/ e documentacao privada do plano contratado.
+
+    Autenticacao:
+        Header: Authorization: Bearer <JURIDICO_PROVIDER_API_KEY>
+
+    Cobertura declarada: 100% dos tribunais, +450 mi processos (2026).
+    Webhook: suportado nos planos anuais com SLA contratual.
+    """
+
+    # Paths de endpoint (sem interpolacao de dados externos na URL base)
+    _PATH_PROCESSO = "/v1/processos"
+    _PATH_MOVIMENTACOES_SUFIXO = "/movimentacoes"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self._api_key = api_key or _exigir_api_key("Judit")
+        self._base_url = _JUDIT_BASE_URL
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def buscar_processo(self, numero_processo: str, tribunal: str | None = None) -> Processo:
+        """Consulta processo na API Judit pelo numero CNJ.
+
+        O numero e enviado como parametro de query, nunca interpolado na URL base.
+        """
+        params: dict[str, str] = {"numero": numero_processo}
+        if tribunal:
+            params["tribunal"] = tribunal
+
+        url = self._base_url + self._PATH_PROCESSO
+        logger.info("judit_buscar_processo", numero=numero_processo, tribunal=tribunal)
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_COMERCIAL) as client:
+                response = await client.get(url, params=params, headers=self._headers())
+        except httpx.TimeoutException as exc:
+            raise JuridicoAPIError(source="Judit", reason="Timeout na consulta") from exc
+        except httpx.RequestError as exc:
+            raise JuridicoAPIError(source="Judit", reason=f"Erro de rede: {exc}") from exc
+
+        if response.status_code == 401:
+            raise JuridicoAPIError(
+                source="Judit",
+                status_code=401,
+                reason="Credencial invalida. Verifique JURIDICO_PROVIDER_API_KEY.",
+            )
+        if response.status_code == 404:
+            raise JuridicoNotFoundError(numero_processo, tribunal)
+        if response.status_code != 200:
+            raise JuridicoAPIError(
+                source="Judit",
+                status_code=response.status_code,
+                reason=response.text[:200],
+            )
+
+        data: dict[str, Any] = response.json()
+        return self._parse_processo(data, tribunal or "")
+
+    async def listar_movimentacoes(
+        self, numero_processo: str, tribunal: str, limite: int = 20
+    ) -> list[Movimentacao]:
+        """Lista movimentacoes de um processo via Judit."""
+        url = self._base_url + self._PATH_PROCESSO + self._PATH_MOVIMENTACOES_SUFIXO
+        params: dict[str, Any] = {"numero": numero_processo, "tribunal": tribunal, "limit": limite}
+
+        logger.info("judit_listar_movimentacoes", numero=numero_processo)
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_COMERCIAL) as client:
+                response = await client.get(url, params=params, headers=self._headers())
+        except httpx.TimeoutException as exc:
+            raise JuridicoAPIError(
+                source="Judit", reason="Timeout ao listar movimentacoes"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise JuridicoAPIError(source="Judit", reason=f"Erro de rede: {exc}") from exc
+
+        if response.status_code == 401:
+            raise JuridicoAPIError(source="Judit", status_code=401, reason="Credencial invalida.")
+        if response.status_code == 404:
+            raise JuridicoNotFoundError(numero_processo, tribunal)
+        if response.status_code != 200:
+            raise JuridicoAPIError(source="Judit", status_code=response.status_code)
+
+        data = response.json()
+        items: list[dict[str, Any]] = data.get(
+            "movimentacoes", data if isinstance(data, list) else []
+        )
+        return [self._parse_movimentacao(m) for m in items[:limite]]
+
+    # ------------------------------------------------------------------
+    # Parsers internos
+    # ------------------------------------------------------------------
+
+    def _parse_processo(self, data: dict[str, Any], tribunal_fallback: str) -> Processo:
+        """Converte resposta Judit para o schema Processo interno.
+
+        INTEGRACAO: Os nomes de campo abaixo seguem a documentacao publica do Judit.
+        Podem precisar de ajuste apos validacao com credencial real.
+        """
+        nivel_sigilo = int(data.get("nivel_sigilo", data.get("nivelSigilo", 0)))
+        numero = str(data.get("numero_processo", data.get("numero", "")))
+        if nivel_sigilo > 0:
+            raise JuridicoSigiloError(numero, nivel_sigilo)
+
+        partes = [
+            Parte(
+                nome=str(p.get("nome", "")),
+                tipo=str(p.get("tipo", "")),
+                polo=p.get("polo"),
+            )
+            for p in data.get("partes", [])
+        ]
+        assuntos = [
+            Assunto(
+                codigo=int(a.get("codigo", 0)),
+                nome=str(a.get("nome", "")),
+                principal=bool(a.get("principal", False)),
+            )
+            for a in data.get("assuntos", [])
+        ]
+        orgao_raw: dict[str, Any] | None = data.get("orgao_julgador")
+        orgao = (
+            OrgaoJulgador(
+                codigo=orgao_raw.get("codigo"),
+                nome=str(orgao_raw.get("nome", "")),
+                codigo_municipio_ibge=orgao_raw.get("codigo_municipio_ibge"),
+            )
+            if orgao_raw
+            else None
+        )
+        movs = [self._parse_movimentacao(m) for m in data.get("movimentacoes", [])]
+
+        return Processo(
+            numero_processo=numero,
+            tribunal=str(data.get("tribunal", tribunal_fallback)),
+            grau=data.get("grau"),
+            data_ajuizamento=_iso_ou_none(data.get("data_ajuizamento")),
+            data_ultima_atualizacao=_iso_ou_none(
+                data.get("data_ultima_atualizacao", data.get("data_atualizacao"))
+            ),
+            nivel_sigilo=nivel_sigilo,
+            classe_codigo=data.get("classe_codigo"),
+            classe_nome=data.get("classe_nome"),
+            assuntos=assuntos,
+            orgao_julgador=orgao,
+            partes=partes,
+            movimentacoes=movs,
+            formato=data.get("formato"),
+            sistema=data.get("sistema"),
+        )
+
+    def _parse_movimentacao(self, data: dict[str, Any]) -> Movimentacao:
+        """Converte item de movimentacao Judit para schema interno."""
+        data_raw = data.get("data_hora", data.get("dataHora", data.get("data", "")))
+        dt = _iso_ou_none(str(data_raw))
+        if dt is None:
+            logger.warning(
+                "movimentacao_sem_data_usando_now",
+                provider="judit",
+                codigo=data.get("codigo"),
+            )
+            dt = datetime.now(tz=timezone.utc)
+        return Movimentacao(
+            codigo=data.get("codigo"),
+            nome=str(data.get("nome", data.get("descricao", ""))),
+            data_hora=dt,
+            complementos=data.get("complementos", []),
+        )
+
+
+# ---------------------------------------------------------------------------
+# EscavadorProvider
+# ---------------------------------------------------------------------------
+
+
+class EscavadorProvider(ProcessoProvider):
+    """Provider baseado na API escavador.com/business/api.
+
+    INTEGRACAO PENDENTE DE VALIDACAO COM CREDENCIAL REAL.
+    Esta implementacao segue a documentacao publica do Escavador (junho de 2026).
+    Antes de usar em producao, validar:
+    - Fluxo de autenticacao OAuth2 (client_credentials) para a API Business
+    - Formato e campos do endpoint de busca por numero CNJ
+    - Paginacao e estrutura de movimentacoes
+    - Limites de credito e comportamento ao esgotar cota
+
+    O Escavador disponibiliza SDK Python oficial no GitHub. Esta implementacao
+    usa httpx diretamente para manter a dependencia minima do projeto.
+
+    Referencia: https://www.escavador.com/business/api
+
+    Autenticacao:
+        Header: Authorization: Bearer <JURIDICO_PROVIDER_API_KEY>
+        (token obtido via OAuth2 client_credentials - a presente implementacao
+        usa o token diretamente; em producao, implementar refresh automatico)
+    """
+
+    _PATH_PROCESSO = "/api/v1/processos"
+    _PATH_MOVIMENTACOES_SUFIXO = "/movimentacoes"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self._api_key = api_key or _exigir_api_key("Escavador")
+        self._base_url = _ESCAVADOR_BASE_URL
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Accept": "application/json",
+        }
+
+    async def buscar_processo(self, numero_processo: str, tribunal: str | None = None) -> Processo:
+        """Busca processo por numero CNJ na API Escavador."""
+        params: dict[str, str] = {"numero_processo": numero_processo}
+        if tribunal:
+            params["tribunal"] = tribunal
+
+        url = self._base_url + self._PATH_PROCESSO
+        logger.info("escavador_buscar_processo", numero=numero_processo)
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_COMERCIAL) as client:
+                response = await client.get(url, params=params, headers=self._headers())
+        except httpx.TimeoutException as exc:
+            raise JuridicoAPIError(source="Escavador", reason="Timeout na consulta") from exc
+        except httpx.RequestError as exc:
+            raise JuridicoAPIError(source="Escavador", reason=f"Erro de rede: {exc}") from exc
+
+        if response.status_code == 401:
+            raise JuridicoAPIError(
+                source="Escavador",
+                status_code=401,
+                reason="Credencial invalida. Verifique JURIDICO_PROVIDER_API_KEY.",
+            )
+        if response.status_code == 404:
+            raise JuridicoNotFoundError(numero_processo, tribunal)
+        if response.status_code != 200:
+            raise JuridicoAPIError(
+                source="Escavador",
+                status_code=response.status_code,
+                reason=response.text[:200],
+            )
+
+        data = response.json()
+        # INTEGRACAO: O Escavador retorna lista em 'items' ou objeto direto
+        item: dict[str, Any] = data.get("items", [data])[0] if isinstance(data, dict) else data
+        return self._parse_processo(item, tribunal or "")
+
+    async def listar_movimentacoes(
+        self, numero_processo: str, tribunal: str, limite: int = 20
+    ) -> list[Movimentacao]:
+        """Lista movimentacoes via Escavador."""
+        # INTEGRACAO: Endpoint pode variar - validar com credencial real
+        url = self._base_url + self._PATH_PROCESSO + self._PATH_MOVIMENTACOES_SUFIXO
+        params: dict[str, Any] = {
+            "numero_processo": numero_processo,
+            "tribunal": tribunal,
+            "per_page": limite,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_COMERCIAL) as client:
+                response = await client.get(url, params=params, headers=self._headers())
+        except httpx.TimeoutException as exc:
+            raise JuridicoAPIError(
+                source="Escavador", reason="Timeout ao listar movimentacoes"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise JuridicoAPIError(source="Escavador", reason=f"Erro de rede: {exc}") from exc
+
+        if response.status_code == 401:
+            raise JuridicoAPIError(
+                source="Escavador", status_code=401, reason="Credencial invalida."
+            )
+        if response.status_code == 404:
+            raise JuridicoNotFoundError(numero_processo, tribunal)
+        if response.status_code != 200:
+            raise JuridicoAPIError(source="Escavador", status_code=response.status_code)
+
+        data = response.json()
+        items: list[dict[str, Any]] = data.get("items", data if isinstance(data, list) else [])
+        return [self._parse_movimentacao(m) for m in items[:limite]]
+
+    def _parse_processo(self, data: dict[str, Any], tribunal_fallback: str) -> Processo:
+        """Converte resposta Escavador para schema Processo interno.
+
+        INTEGRACAO: Nomes de campo seguem documentacao publica do Escavador.
+        Validar com credencial real antes de producao.
+        """
+        nivel_sigilo = int(data.get("nivel_sigilo", 0))
+        numero = str(data.get("numero_processo", data.get("numero", "")))
+        if nivel_sigilo > 0:
+            raise JuridicoSigiloError(numero, nivel_sigilo)
+
+        partes = [
+            Parte(
+                nome=str(p.get("nome", "")),
+                tipo=str(p.get("tipo_participacao", p.get("tipo", ""))),
+                polo=p.get("polo"),
+            )
+            for p in data.get("partes", [])
+        ]
+        # LGPD: Campo cpf/cnpj ignorado propositalmente mesmo se presente na resposta
+        assuntos = [
+            Assunto(
+                codigo=int(a.get("codigo", 0)),
+                nome=str(a.get("nome", "")),
+                principal=bool(a.get("principal", False)),
+            )
+            for a in data.get("assuntos", [])
+        ]
+        orgao_raw: dict[str, Any] | None = data.get("orgao_julgador")
+        orgao = (
+            OrgaoJulgador(
+                codigo=orgao_raw.get("codigo"),
+                nome=str(orgao_raw.get("nome", "")),
+            )
+            if orgao_raw
+            else None
+        )
+
+        return Processo(
+            numero_processo=numero,
+            tribunal=str(data.get("tribunal", tribunal_fallback)),
+            grau=data.get("grau"),
+            data_ajuizamento=_iso_ou_none(data.get("data_ajuizamento")),
+            data_ultima_atualizacao=_iso_ou_none(data.get("data_ultima_atualizacao")),
+            nivel_sigilo=nivel_sigilo,
+            classe_codigo=data.get("classe", {}).get("codigo")
+            if isinstance(data.get("classe"), dict)
+            else None,
+            classe_nome=data.get("classe", {}).get("nome")
+            if isinstance(data.get("classe"), dict)
+            else None,
+            assuntos=assuntos,
+            orgao_julgador=orgao,
+            partes=partes,
+            movimentacoes=[self._parse_movimentacao(m) for m in data.get("movimentacoes", [])],
+            formato=data.get("formato"),
+            sistema=data.get("sistema"),
+        )
+
+    def _parse_movimentacao(self, data: dict[str, Any]) -> Movimentacao:
+        """Converte item de movimentacao Escavador para schema interno."""
+        data_raw = data.get("data", data.get("data_hora", ""))
+        dt = _iso_ou_none(str(data_raw))
+        if dt is None:
+            logger.warning(
+                "movimentacao_sem_data_usando_now",
+                provider="escavador",
+                codigo=data.get("codigo_tpu"),
+            )
+            dt = datetime.now(tz=timezone.utc)
+        return Movimentacao(
+            codigo=data.get("codigo_tpu"),
+            nome=str(data.get("tipo", data.get("nome", ""))),
+            data_hora=dt,
+            complementos=data.get("complementos", []),
+        )
+
+
+# ---------------------------------------------------------------------------
+# TrackJudProvider
+# ---------------------------------------------------------------------------
+
+
+class TrackJudProvider(ProcessoProvider):
+    """Provider baseado na API trackjud.com.br.
+
+    INTEGRACAO PENDENTE DE VALIDACAO COM CREDENCIAL REAL.
+    Esta implementacao segue a documentacao publica do TrackJud (junho de 2026),
+    incluindo a especificacao OpenAPI 3.1 disponivel no site.
+    Antes de usar em producao, validar:
+    - Endpoints exatos (documentacao OpenAPI pode ter diferido desde junho/2026)
+    - Formato de autenticacao (Bearer token ou Api-Key customizado)
+    - Cobertura real de tribunais (declarado: 10 estados - SP, RJ, PE, AM, DF +)
+    - Comportamento ao extrapolar cota (R$ 0,10/consulta/tribunal)
+
+    LIMITACAO CONHECIDA: TrackJud cobre parcialmente os tribunais (10 estados
+    declarados em junho de 2026, sem cobertura nacional completa). Ideal para
+    MVP/prototipo. Para producao com cobertura nacional, prefira Judit.
+
+    Referencia: https://trackjud.com.br/pricing e documentacao OpenAPI 3.1.
+
+    Autenticacao:
+        Header: X-Api-Key: <JURIDICO_PROVIDER_API_KEY>
+    """
+
+    _PATH_PROCESSO = "/v1/processos/consultar"
+    _PATH_MOVIMENTACOES = "/v1/processos/movimentacoes"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self._api_key = api_key or _exigir_api_key("TrackJud")
+        self._base_url = _TRACKJUD_BASE_URL
+
+    def _headers(self) -> dict[str, str]:
+        # INTEGRACAO: TrackJud usa X-Api-Key conforme documentacao OpenAPI 3.1
+        return {
+            "X-Api-Key": self._api_key,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def buscar_processo(self, numero_processo: str, tribunal: str | None = None) -> Processo:
+        """Consulta processo na API TrackJud.
+
+        O TrackJud aceita POST com corpo JSON contendo o numero CNJ.
+        """
+        url = self._base_url + self._PATH_PROCESSO
+        body: dict[str, Any] = {"numero_processo": numero_processo}
+        if tribunal:
+            body["tribunal"] = tribunal
+
+        logger.info("trackjud_buscar_processo", numero=numero_processo)
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_COMERCIAL) as client:
+                response = await client.post(url, json=body, headers=self._headers())
+        except httpx.TimeoutException as exc:
+            raise JuridicoAPIError(source="TrackJud", reason="Timeout na consulta") from exc
+        except httpx.RequestError as exc:
+            raise JuridicoAPIError(source="TrackJud", reason=f"Erro de rede: {exc}") from exc
+
+        if response.status_code == 401:
+            raise JuridicoAPIError(
+                source="TrackJud",
+                status_code=401,
+                reason="Credencial invalida. Verifique JURIDICO_PROVIDER_API_KEY.",
+            )
+        if response.status_code == 404:
+            raise JuridicoNotFoundError(numero_processo, tribunal)
+        if response.status_code != 200:
+            raise JuridicoAPIError(
+                source="TrackJud",
+                status_code=response.status_code,
+                reason=response.text[:200],
+            )
+
+        data = response.json()
+        return self._parse_processo(data, tribunal or "")
+
+    async def listar_movimentacoes(
+        self, numero_processo: str, tribunal: str, limite: int = 20
+    ) -> list[Movimentacao]:
+        """Lista movimentacoes via TrackJud."""
+        url = self._base_url + self._PATH_MOVIMENTACOES
+        body: dict[str, Any] = {
+            "numero_processo": numero_processo,
+            "tribunal": tribunal,
+            "limite": limite,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_COMERCIAL) as client:
+                response = await client.post(url, json=body, headers=self._headers())
+        except httpx.TimeoutException as exc:
+            raise JuridicoAPIError(
+                source="TrackJud", reason="Timeout ao listar movimentacoes"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise JuridicoAPIError(source="TrackJud", reason=f"Erro de rede: {exc}") from exc
+
+        if response.status_code == 401:
+            raise JuridicoAPIError(
+                source="TrackJud", status_code=401, reason="Credencial invalida."
+            )
+        if response.status_code == 404:
+            raise JuridicoNotFoundError(numero_processo, tribunal)
+        if response.status_code != 200:
+            raise JuridicoAPIError(source="TrackJud", status_code=response.status_code)
+
+        data = response.json()
+        items: list[dict[str, Any]] = data.get(
+            "movimentacoes", data if isinstance(data, list) else []
+        )
+        return [self._parse_movimentacao(m) for m in items[:limite]]
+
+    def _parse_processo(self, data: dict[str, Any], tribunal_fallback: str) -> Processo:
+        """Converte resposta TrackJud para schema Processo interno.
+
+        INTEGRACAO: Nomes de campo baseados na documentacao OpenAPI 3.1 do TrackJud.
+        Validar com credencial real antes de producao.
+        """
+        nivel_sigilo = int(data.get("nivel_sigilo", 0))
+        numero = str(data.get("numero_processo", data.get("numero", "")))
+        if nivel_sigilo > 0:
+            raise JuridicoSigiloError(numero, nivel_sigilo)
+
+        partes = [
+            Parte(
+                nome=str(p.get("nome", "")),
+                tipo=str(p.get("tipo", "")),
+                polo=p.get("polo"),
+            )
+            for p in data.get("partes", [])
+        ]
+        orgao_raw: dict[str, Any] | None = data.get("orgao_julgador", data.get("orgao"))
+        orgao = (
+            OrgaoJulgador(
+                codigo=orgao_raw.get("codigo"),
+                nome=str(orgao_raw.get("nome", "")),
+                codigo_municipio_ibge=orgao_raw.get("codigo_municipio_ibge"),
+            )
+            if orgao_raw
+            else None
+        )
+
+        return Processo(
+            numero_processo=numero,
+            tribunal=str(data.get("tribunal", tribunal_fallback)),
+            grau=data.get("grau"),
+            data_ajuizamento=_iso_ou_none(data.get("data_ajuizamento")),
+            data_ultima_atualizacao=_iso_ou_none(data.get("data_ultima_atualizacao")),
+            nivel_sigilo=nivel_sigilo,
+            classe_codigo=data.get("classe_codigo"),
+            classe_nome=data.get("classe_nome"),
+            assuntos=[],
+            orgao_julgador=orgao,
+            partes=partes,
+            movimentacoes=[self._parse_movimentacao(m) for m in data.get("movimentacoes", [])],
+            formato=data.get("formato"),
+            sistema=data.get("sistema"),
+        )
+
+    def _parse_movimentacao(self, data: dict[str, Any]) -> Movimentacao:
+        """Converte item de movimentacao TrackJud para schema interno."""
+        data_raw = data.get("data_hora", data.get("data", ""))
+        dt = _iso_ou_none(str(data_raw))
+        if dt is None:
+            logger.warning(
+                "movimentacao_sem_data_usando_now",
+                provider="trackjud",
+                codigo=data.get("codigo"),
+            )
+            dt = datetime.now(tz=timezone.utc)
+        return Movimentacao(
+            codigo=data.get("codigo"),
+            nome=str(data.get("nome", data.get("descricao", ""))),
+            data_hora=dt,
+            complementos=data.get("complementos", []),
+        )
+
+
+__all__ = ["EscavadorProvider", "JuditProvider", "TrackJudProvider"]

--- a/src/mcp_juridico_brasil/comercial/registry.py
+++ b/src/mcp_juridico_brasil/comercial/registry.py
@@ -1,0 +1,192 @@
+"""Seletor de provider por configuracao de ambiente.
+
+Variaveis relevantes:
+- JURIDICO_PROVIDER: datajud | judit | escavador | trackjud  (default: datajud)
+- JURIDICO_PROVIDER_API_KEY: chave do provider comercial (obrigatoria se != datajud)
+
+Logica de selecao:
+1. Le JURIDICO_PROVIDER (case-insensitive).
+2. Se for "datajud" ou vazio, instancia DataJudProvider diretamente.
+3. Se for um provider comercial, instancia o provider correspondente com a chave
+   lida de JURIDICO_PROVIDER_API_KEY.
+4. Se a chave estiver ausente ou o provider comercial falhar ao ser instanciado,
+   o caller pode usar FallbackProvider para degradacao transparente para DataJud.
+
+O FallbackProvider e o mecanismo de degradacao automatica descrito na Fase 3.
+Ele envolve um provider comercial e, em caso de qualquer excecao (timeout, auth,
+erro de API), chama o DataJudProvider silenciosamente com log de aviso.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+from mcp_juridico_brasil._core.errors import JuridicoAPIError, JuridicoSigiloError
+from mcp_juridico_brasil._core.logging import get_logger
+from mcp_juridico_brasil.datajud.provider import DataJudProvider, ProcessoProvider
+from mcp_juridico_brasil.shared.schemas import Movimentacao, Processo
+
+logger = get_logger(__name__)
+
+# Nomes aceitos de providers
+_PROVIDERS_COMERCIAIS = {"judit", "escavador", "trackjud"}
+
+
+def selecionar_provider() -> ProcessoProvider:
+    """Retorna o provider ativo com base na configuracao de ambiente.
+
+    Leitura de JURIDICO_PROVIDER e JURIDICO_PROVIDER_API_KEY feita em
+    tempo de chamada (permite trocar sem reiniciar em testes).
+
+    Returns:
+        ProcessoProvider: instancia pronta para uso, com fallback embutido
+        se o provider selecionado for comercial.
+
+    Raises:
+        ValueError: se JURIDICO_PROVIDER tiver valor desconhecido.
+    """
+    nome = os.environ.get("JURIDICO_PROVIDER", "datajud").strip().lower()
+
+    if nome in ("datajud", ""):
+        logger.info("provider_selecionado", provider="datajud")
+        return DataJudProvider()
+
+    if nome not in _PROVIDERS_COMERCIAIS:
+        raise ValueError(
+            f"Provider desconhecido: {nome!r}. "
+            f"Valores aceitos: datajud, {', '.join(sorted(_PROVIDERS_COMERCIAIS))}."
+        )
+
+    api_key = os.environ.get("JURIDICO_PROVIDER_API_KEY", "").strip()
+    comercial = _instanciar_comercial(nome, api_key)
+
+    if comercial is None:
+        logger.warning(
+            "provider_comercial_indisponivel_usando_datajud",
+            provider_solicitado=nome,
+            motivo="Chave ausente ou provider nao instanciado",
+        )
+        return DataJudProvider()
+
+    logger.info("provider_selecionado", provider=nome, com_fallback=True)
+    return FallbackProvider(comercial, DataJudProvider())
+
+
+def _instanciar_comercial(nome: str, api_key: str) -> ProcessoProvider | None:
+    """Tenta instanciar o provider comercial.
+
+    Retorna None se a chave estiver ausente (em vez de lancar excecao),
+    para que o seletor possa degradar para DataJud automaticamente.
+    """
+    # Importacao local para evitar ciclo e manter modulo registry leve
+    from mcp_juridico_brasil.comercial.providers import (
+        EscavadorProvider,
+        JuditProvider,
+        TrackJudProvider,
+    )
+
+    if not api_key:
+        return None
+
+    _mapa: dict[str, Callable[[], ProcessoProvider]] = {
+        "judit": lambda: JuditProvider(api_key=api_key),
+        "escavador": lambda: EscavadorProvider(api_key=api_key),
+        "trackjud": lambda: TrackJudProvider(api_key=api_key),
+    }
+    fabrica = _mapa.get(nome)
+    # O seletor ja validou 'nome' contra _PROVIDERS_COMERCIAIS antes de chamar esta funcao.
+    # Se fabrica for None aqui, ha inconsistencia interna entre os dois dicts.
+    assert fabrica is not None, (
+        f"Provider {nome!r} esta em _PROVIDERS_COMERCIAIS mas ausente do _mapa interno. "
+        "Adicione a fabrica correspondente."
+    )
+    try:
+        return fabrica()
+    except JuridicoAPIError:
+        # Caso esperado: chave ausente ou invalida. O seletor degrada para DataJud.
+        logger.warning("provider_comercial_chave_invalida", provider=nome)
+        return None
+    except Exception as exc:
+        # Bug inesperado na instanciacao - logar com traceback completo para diagnostico.
+        logger.exception(
+            "provider_comercial_instancia_erro_inesperado",
+            provider=nome,
+            tipo_erro=type(exc).__name__,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# FallbackProvider
+# ---------------------------------------------------------------------------
+
+
+class FallbackProvider(ProcessoProvider):
+    """Envolve um provider primario e degrada para o secundario em caso de falha.
+
+    O fallback e transparente para as tools MCP: elas nao sabem qual provider
+    respondeu. Um log de aviso e emitido quando o fallback e ativado.
+
+    ATENCAO: JuridicoSigiloError do provider primario NUNCA e silenciado.
+    Sigilo e definitivo e nao deve ser contornado tentando outro provider.
+    """
+
+    def __init__(self, primario: ProcessoProvider, secundario: ProcessoProvider) -> None:
+        self._primario = primario
+        self._secundario = secundario
+
+    async def buscar_processo(self, numero_processo: str, tribunal: str | None = None) -> Processo:
+        """Busca com fallback automatico."""
+        try:
+            return await self._primario.buscar_processo(numero_processo, tribunal)
+        except JuridicoSigiloError:
+            # Sigilo nao tem fallback - propaga imediatamente
+            raise
+        except Exception as exc:
+            logger.warning(
+                "provider_primario_falhou_usando_fallback",
+                numero=numero_processo,
+                erro=type(exc).__name__,
+                detalhe=str(exc)[:200],
+            )
+            return await self._secundario.buscar_processo(numero_processo, tribunal)
+
+    async def listar_movimentacoes(
+        self, numero_processo: str, tribunal: str, limite: int = 20
+    ) -> list[Movimentacao]:
+        """Lista movimentacoes com fallback automatico."""
+        try:
+            return await self._primario.listar_movimentacoes(numero_processo, tribunal, limite)
+        except JuridicoSigiloError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "provider_primario_falhou_usando_fallback",
+                numero=numero_processo,
+                erro=type(exc).__name__,
+                detalhe=str(exc)[:200],
+            )
+            return await self._secundario.listar_movimentacoes(numero_processo, tribunal, limite)
+
+    async def verificar_atualizacao(
+        self, numero_processo: str, tribunal: str, desde_iso: str
+    ) -> bool:
+        """Verifica atualizacao com fallback automatico."""
+        try:
+            return await self._primario.verificar_atualizacao(numero_processo, tribunal, desde_iso)
+        except JuridicoSigiloError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "provider_primario_falhou_usando_fallback",
+                numero=numero_processo,
+                erro=type(exc).__name__,
+                detalhe=str(exc)[:200],
+            )
+            return await self._secundario.verificar_atualizacao(
+                numero_processo, tribunal, desde_iso
+            )
+
+
+__all__ = ["FallbackProvider", "selecionar_provider"]

--- a/src/mcp_juridico_brasil/comercial/webhook.py
+++ b/src/mcp_juridico_brasil/comercial/webhook.py
@@ -1,0 +1,255 @@
+"""Handler de webhook push de providers comerciais.
+
+ESCOPO DE DEPLOY:
+    Esta implementacao entrega o HANDLER (logica de validacao e processamento),
+    nao um servidor HTTP completo. A exposicao do endpoint HTTP e responsabilidade
+    do deploy - as opcoes recomendadas sao:
+
+    1. FastAPI/Starlette (producao recomendada):
+        ```python
+        from fastapi import FastAPI, Header, HTTPException, Request
+        from mcp_juridico_brasil.comercial.webhook import processar_webhook
+
+        app = FastAPI()
+
+        @app.post("/webhook/movimentacao")
+        async def endpoint_webhook(request: Request, x_provider_signature: str = Header(...)):
+            payload_bytes = await request.body()
+            payload_json = await request.json()
+            resultado = processar_webhook(
+                payload=payload_json,
+                assinatura_header=x_provider_signature,
+                payload_bytes=payload_bytes,
+                webhook_secret=os.environ["JURIDICO_WEBHOOK_SECRET"],
+            )
+            return resultado
+        ```
+
+    2. AWS Lambda / GCP Cloud Functions (serverless):
+        Adaptar a assinatura para o evento do provedor de nuvem e chamar
+        processar_webhook com os mesmos argumentos.
+
+    3. Integrado ao servidor FastMCP (HTTP streamable):
+        Montar um router customizado no mesmo processo do MCP, se o
+        framework FastMCP suportar mounting de routers adicionais.
+
+    Em todos os casos, o JURIDICO_WEBHOOK_SECRET deve ser o mesmo segredo
+    configurado no painel do provider comercial para assinar os payloads.
+
+SEGURANCA:
+    - Assinatura HMAC-SHA256 validada ANTES de processar qualquer dado.
+    - Payload malformado e rejeitado com mensagem de erro, sem stacktrace.
+    - Processo sigiloso detectado no payload e bloqueado (nivel_sigilo > 0).
+    - O segredo do webhook e lido exclusivamente de variavel de ambiente.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import AwareDatetime, BaseModel, Field, ValidationError
+
+from mcp_juridico_brasil._core.errors import JuridicoSigiloError
+from mcp_juridico_brasil._core.logging import get_logger
+from mcp_juridico_brasil.monitoramento import store
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schema de payload de webhook
+# ---------------------------------------------------------------------------
+
+
+class MovimentacaoWebhook(BaseModel):
+    """Movimentacao recebida em payload de webhook de provider comercial."""
+
+    codigo: int | None = None
+    nome: str
+    data_hora: str  # ISO 8601 - convertido para datetime ao salvar no store
+    complementos: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class WebhookPayload(BaseModel):
+    """Payload normalizado de notificacao push de provider comercial.
+
+    Providers diferentes usam campos ligeiramente diferentes. Este schema
+    aceita os formatos dos tres providers suportados (Judit, Escavador, TrackJud)
+    usando aliases e campos opcionais.
+
+    INTEGRACAO: Validar com payload real de cada provider antes de producao.
+    """
+
+    numero_processo: str
+    tribunal: str
+    nivel_sigilo: int = Field(default=0, ge=0)
+    # AwareDatetime (Pydantic v2) valida formato ISO 8601 e exige fuso horario explicito.
+    # Providers que enviem strings malformadas (ex: "ontem") serao rejeitados na validacao
+    # do schema, antes de qualquer processamento.
+    data_ultima_atualizacao: AwareDatetime | None = None
+    movimentacoes: list[MovimentacaoWebhook] = Field(default_factory=list)
+    # Campo livre para metadados do provider (nao persistido no store interno)
+    metadados_provider: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Validacao de assinatura HMAC
+# ---------------------------------------------------------------------------
+
+
+class WebhookAssinaturaInvalidaError(Exception):
+    """Assinatura HMAC do webhook nao confere com o payload recebido."""
+
+
+def _validar_assinatura_hmac(
+    payload_bytes: bytes,
+    assinatura_header: str,
+    segredo: str,
+) -> None:
+    """Valida assinatura HMAC-SHA256 do payload recebido.
+
+    A maioria dos providers comerciais assina o payload com HMAC-SHA256
+    usando o segredo configurado no painel. O header de assinatura tipicamente
+    tem o formato 'sha256=<hex_digest>'.
+
+    Args:
+        payload_bytes: Corpo bruto da requisicao HTTP (bytes).
+        assinatura_header: Valor do header de assinatura (ex: 'sha256=abc123...').
+        segredo: Segredo HMAC compartilhado com o provider (JURIDICO_WEBHOOK_SECRET).
+
+    Raises:
+        WebhookAssinaturaInvalidaError: Se a assinatura nao for valida.
+    """
+    # Remove prefixo 'sha256=' se presente (padrao Judit, Digesto, GitHub-style)
+    assinatura_recebida = assinatura_header.removeprefix("sha256=").strip()
+
+    mac = hmac.new(
+        key=segredo.encode("utf-8"),
+        msg=payload_bytes,
+        digestmod=hashlib.sha256,
+    )
+    assinatura_esperada = mac.hexdigest()
+
+    # Comparacao em tempo constante para evitar timing attacks
+    if not hmac.compare_digest(assinatura_esperada, assinatura_recebida):
+        logger.warning(
+            "webhook_assinatura_invalida",
+            assinatura_recebida_prefixo=assinatura_recebida[:8] + "...",
+        )
+        raise WebhookAssinaturaInvalidaError(
+            "Assinatura HMAC do webhook invalida. "
+            "Verifique JURIDICO_WEBHOOK_SECRET e a configuracao no painel do provider."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Handler principal
+# ---------------------------------------------------------------------------
+
+
+def processar_webhook(
+    payload: dict[str, Any],
+    assinatura_header: str,
+    payload_bytes: bytes,
+    webhook_secret: str | None = None,
+) -> dict[str, Any]:
+    """Valida e processa um payload de webhook de movimentacao processual.
+
+    Fluxo:
+        1. Valida assinatura HMAC-SHA256 (rejeita se invalida).
+        2. Valida schema do payload com Pydantic (rejeita se malformado).
+        3. Verifica nivel_sigilo (bloqueia se > 0).
+        4. Atualiza o store de snapshots com os dados recebidos.
+        5. Retorna resumo do processamento.
+
+    Args:
+        payload: Dicionario com o payload JSON do webhook.
+        assinatura_header: Valor do header de assinatura do provider.
+        payload_bytes: Corpo bruto da requisicao (para verificacao HMAC).
+        webhook_secret: Segredo HMAC. Se None, le de JURIDICO_WEBHOOK_SECRET.
+
+    Returns:
+        Dicionario com resultado do processamento:
+        {
+            "processado": True,
+            "numero_processo": "...",
+            "tribunal": "...",
+            "movimentacoes_recebidas": N,
+            "capturado_em": "ISO8601",
+        }
+
+    Raises:
+        WebhookAssinaturaInvalidaError: Assinatura HMAC incorreta.
+        JuridicoSigiloError: Processo em segredo de justica - nunca processa.
+        ValueError: Payload malformado ou segredo ausente.
+    """
+    # 1. Resolver segredo
+    segredo = webhook_secret or os.environ.get("JURIDICO_WEBHOOK_SECRET", "").strip()
+    if not segredo:
+        raise ValueError("Segredo de webhook ausente. Configure JURIDICO_WEBHOOK_SECRET.")
+
+    # 2. Validar assinatura HMAC antes de qualquer outra operacao
+    _validar_assinatura_hmac(payload_bytes, assinatura_header, segredo)
+
+    # 3. Validar schema do payload
+    try:
+        webhook = WebhookPayload.model_validate(payload)
+    except ValidationError as exc:
+        erros = exc.errors(include_url=False)
+        logger.warning("webhook_payload_invalido", erros=erros)
+        raise ValueError(f"Payload de webhook malformado: {erros}") from exc
+
+    # 4. Bloquear processo sigiloso - sem fallback, sem processamento parcial
+    if webhook.nivel_sigilo > 0:
+        logger.warning(
+            "webhook_processo_sigiloso_bloqueado",
+            numero=webhook.numero_processo,
+            nivel=webhook.nivel_sigilo,
+        )
+        raise JuridicoSigiloError(webhook.numero_processo, webhook.nivel_sigilo)
+
+    # 5. Atualizar store de snapshots
+    agora = datetime.now(tz=timezone.utc).isoformat()
+    dados_snapshot: dict[str, Any] = {
+        "numero_processo": webhook.numero_processo,
+        "tribunal": webhook.tribunal,
+        "data_ultima_atualizacao": webhook.data_ultima_atualizacao.isoformat()
+        if webhook.data_ultima_atualizacao
+        else None,
+        "movimentacoes": [m.model_dump() for m in webhook.movimentacoes],
+        "fonte": "webhook",
+        "recebido_em": agora,
+        "metadados_provider": webhook.metadados_provider,
+    }
+
+    store.salvar_snapshot(
+        numero_processo=webhook.numero_processo,
+        tribunal=webhook.tribunal,
+        dados=dados_snapshot,
+    )
+
+    logger.info(
+        "webhook_processado",
+        numero=webhook.numero_processo,
+        movimentacoes=len(webhook.movimentacoes),
+    )
+
+    return {
+        "processado": True,
+        "numero_processo": webhook.numero_processo,
+        "tribunal": webhook.tribunal,
+        "movimentacoes_recebidas": len(webhook.movimentacoes),
+        "capturado_em": agora,
+    }
+
+
+__all__ = [
+    "MovimentacaoWebhook",
+    "WebhookAssinaturaInvalidaError",
+    "WebhookPayload",
+    "processar_webhook",
+]

--- a/src/mcp_juridico_brasil/datajud/provider.py
+++ b/src/mcp_juridico_brasil/datajud/provider.py
@@ -52,7 +52,7 @@ class ProcessoProvider(ABC):
             JuridicoValidationError: Se desde_iso nao for uma data ISO 8601 valida.
         """
         try:
-            desde = datetime.fromisoformat(desde_iso)
+            desde = datetime.fromisoformat(desde_iso.replace("Z", "+00:00"))
         except ValueError as exc:
             raise JuridicoValidationError(
                 "desde_iso",

--- a/src/mcp_juridico_brasil/datajud/provider.py
+++ b/src/mcp_juridico_brasil/datajud/provider.py
@@ -1,7 +1,7 @@
-"""Interface abstrata ProcessoProvider e implementação DataJudProvider.
+"""Interface abstrata ProcessoProvider e implementacao DataJudProvider.
 
 O design de provider abstrato permite trocar a fonte de dados sem alterar
-as tools MCP. Em produção, um provider comercial (Judit, Escavador) pode
+as tools MCP. Em producao, um provider comercial (Judit, Escavador) pode
 substituir o DataJud para tribunais com maior defasagem ou para consultas
 por CPF/CNPJ.
 
@@ -14,6 +14,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 
+from mcp_juridico_brasil._core.errors import JuridicoValidationError
 from mcp_juridico_brasil.shared.schemas import Movimentacao, Processo
 
 from .client import DataJudClient
@@ -31,19 +32,44 @@ class ProcessoProvider(ABC):
     async def listar_movimentacoes(
         self, numero_processo: str, tribunal: str, limite: int = 20
     ) -> list[Movimentacao]:
-        """Retorna as movimentações mais recentes."""
+        """Retorna as movimentacoes mais recentes."""
         ...
 
-    @abstractmethod
     async def verificar_atualizacao(
         self, numero_processo: str, tribunal: str, desde_iso: str
     ) -> bool:
-        """Retorna True se o processo teve atualização após a data informada."""
-        ...
+        """Retorna True se o processo teve atualizacao apos a data informada.
+
+        Implementacao padrao: delega para buscar_processo e compara datas.
+        Providers com endpoint dedicado de check-update podem sobrescrever.
+
+        Args:
+            numero_processo: Numero CNJ do processo.
+            tribunal: Sigla do tribunal.
+            desde_iso: Data de corte em formato ISO 8601 (ex: '2024-06-01T00:00:00Z').
+
+        Raises:
+            JuridicoValidationError: Se desde_iso nao for uma data ISO 8601 valida.
+        """
+        try:
+            desde = datetime.fromisoformat(desde_iso)
+        except ValueError as exc:
+            raise JuridicoValidationError(
+                "desde_iso",
+                desde_iso,
+                "Formato ISO 8601 esperado (ex: '2024-06-01T00:00:00Z').",
+            ) from exc
+        if desde.tzinfo is None:
+            desde = desde.replace(tzinfo=timezone.utc)
+
+        processo = await self.buscar_processo(numero_processo, tribunal)
+        if not processo.data_ultima_atualizacao:
+            return False
+        return processo.data_ultima_atualizacao > desde
 
 
 class DataJudProvider(ProcessoProvider):
-    """Provider concreto baseado na API pública DataJud (CNJ).
+    """Provider concreto baseado na API publica DataJud (CNJ).
 
     Cobertura: 91 tribunais. Zero custo. Sem webhook (polling).
     Defasagem: T+1 a T+7 dias dependendo do tribunal.
@@ -61,17 +87,6 @@ class DataJudProvider(ProcessoProvider):
         self, numero_processo: str, tribunal: str, limite: int = 20
     ) -> list[Movimentacao]:
         return await self._client.listar_movimentacoes(numero_processo, tribunal, limite)
-
-    async def verificar_atualizacao(
-        self, numero_processo: str, tribunal: str, desde_iso: str
-    ) -> bool:
-        processo = await self._client.buscar_por_numero(numero_processo, tribunal)
-        if not processo.data_ultima_atualizacao:
-            return False
-        desde = datetime.fromisoformat(desde_iso)
-        if desde.tzinfo is None:
-            desde = desde.replace(tzinfo=timezone.utc)
-        return processo.data_ultima_atualizacao > desde
 
 
 __all__ = ["DataJudProvider", "ProcessoProvider"]

--- a/src/mcp_juridico_brasil/monitoramento/tools.py
+++ b/src/mcp_juridico_brasil/monitoramento/tools.py
@@ -43,7 +43,7 @@ async def monitorar_processo(
         )
 
     try:
-        datetime.fromisoformat(desde_iso)
+        datetime.fromisoformat(desde_iso.replace("Z", "+00:00"))
     except ValueError as exc:
         raise JuridicoValidationError(
             field="desde_iso",
@@ -63,7 +63,7 @@ async def monitorar_processo(
     ultima = processo.data_ultima_atualizacao
     ultima_iso = ultima.isoformat() if ultima else None
 
-    desde = datetime.fromisoformat(desde_iso)
+    desde = datetime.fromisoformat(desde_iso.replace("Z", "+00:00"))
     if desde.tzinfo is None:
         desde = desde.replace(tzinfo=timezone.utc)
     houve_atualizacao = ultima is not None and ultima > desde

--- a/tests/test_comercial_providers.py
+++ b/tests/test_comercial_providers.py
@@ -1,0 +1,663 @@
+"""Testes dos providers comerciais (Judit, Escavador, TrackJud) com mocks HTTP.
+
+Todos os testes sao deterministicos e nao requerem credencial real.
+Usa respx para interceptar chamadas httpx.
+
+Cenarios cobertos por provider:
+- Consulta bem-sucedida (happy path)
+- Erro de autenticacao (HTTP 401)
+- Timeout (httpx.TimeoutException)
+- Processo nao encontrado (HTTP 404)
+- Processo sigiloso (nivel_sigilo > 0 na resposta)
+- verificar_atualizacao com data ISO valida (retorno True/False)
+- verificar_atualizacao com data ISO invalida (JuridicoValidationError)
+- _parse_movimentacao com data ausente (warning + fallback para now)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import respx
+from httpx import Response, TimeoutException
+
+from mcp_juridico_brasil._core.errors import (
+    JuridicoAPIError,
+    JuridicoNotFoundError,
+    JuridicoSigiloError,
+    JuridicoValidationError,
+)
+from mcp_juridico_brasil.comercial.providers import (
+    EscavadorProvider,
+    JuditProvider,
+    TrackJudProvider,
+)
+
+# ---------------------------------------------------------------------------
+# Constantes
+# ---------------------------------------------------------------------------
+
+NUMERO = "00012345620238260100"
+TRIBUNAL = "TJSP"
+API_KEY = "chave-fake-para-testes"
+
+JUDIT_URL = "https://api.judit.io/v1/processos"
+JUDIT_MOV_URL = "https://api.judit.io/v1/processos/movimentacoes"
+ESCAVADOR_URL = "https://api.escavador.com/api/v1/processos"
+ESCAVADOR_MOV_URL = "https://api.escavador.com/api/v1/processos/movimentacoes"
+TRACKJUD_URL = "https://api.trackjud.com.br/v1/processos/consultar"
+TRACKJUD_MOV_URL = "https://api.trackjud.com.br/v1/processos/movimentacoes"
+
+# ---------------------------------------------------------------------------
+# Fixtures de payload
+# ---------------------------------------------------------------------------
+
+
+def _payload_processo(
+    numero: str = NUMERO,
+    tribunal: str = TRIBUNAL,
+    nivel_sigilo: int = 0,
+) -> dict[str, Any]:
+    """Payload padrao de processo publico."""
+    return {
+        "numero_processo": numero,
+        "tribunal": tribunal,
+        "nivel_sigilo": nivel_sigilo,
+        "grau": "G1",
+        "data_ajuizamento": "2023-01-15T00:00:00Z",
+        "data_ultima_atualizacao": "2024-06-01T12:00:00Z",
+        "classe_codigo": 7,
+        "classe_nome": "Procedimento Comum Civel",
+        "partes": [
+            {"nome": "Joao Silva", "tipo": "Autor", "polo": "ativo"},
+            {"nome": "Empresa Ltda", "tipo": "Reu", "polo": "passivo"},
+        ],
+        "assuntos": [{"codigo": 10374, "nome": "Indenizacao por Dano Moral", "principal": True}],
+        "orgao_julgador": {
+            "codigo": 1,
+            "nome": "1a Vara Civel de Sao Paulo",
+            "codigo_municipio_ibge": 3550308,
+        },
+        "movimentacoes": [
+            {
+                "codigo": 22,
+                "nome": "Despacho",
+                "data_hora": "2024-06-01T12:00:00Z",
+                "complementos": [],
+            }
+        ],
+        "formato": "Eletronico",
+        "sistema": "eSAJ",
+    }
+
+
+def _payload_movimentacoes() -> dict[str, Any]:
+    """Payload de lista de movimentacoes."""
+    return {
+        "movimentacoes": [
+            {
+                "codigo": 22,
+                "nome": "Despacho",
+                "data_hora": "2024-06-01T12:00:00Z",
+                "complementos": [],
+            },
+            {
+                "codigo": 11,
+                "nome": "Distribuicao",
+                "data_hora": "2023-01-15T09:00:00Z",
+                "complementos": [],
+            },
+        ]
+    }
+
+
+# ===========================================================================
+# JUDIT
+# ===========================================================================
+
+
+class TestJuditProviderBuscarProcesso:
+    """Testes de buscar_processo para o JuditProvider."""
+
+    @pytest.mark.asyncio
+    async def test_consulta_ok_retorna_processo(self) -> None:
+        """Happy path: retorna Processo com dados corretos."""
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(return_value=Response(200, json=_payload_processo()))
+            provider = JuditProvider(api_key=API_KEY)
+            processo = await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert processo.numero_processo == NUMERO
+        assert processo.tribunal == TRIBUNAL
+        assert processo.nivel_sigilo == 0
+        assert len(processo.partes) == 2
+        assert processo.partes[0].nome == "Joao Silva"
+        assert len(processo.movimentacoes) == 1
+
+    @pytest.mark.asyncio
+    async def test_erro_auth_lanca_juridico_api_error(self) -> None:
+        """HTTP 401 deve lancar JuridicoAPIError com status_code 401."""
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(return_value=Response(401, json={"error": "Unauthorized"}))
+            provider = JuditProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError) as exc_info:
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert exc_info.value.detail.get("status_code") == 401
+        assert "Judit" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_timeout_lanca_juridico_api_error(self) -> None:
+        """Timeout deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(side_effect=TimeoutException("timeout"))
+            provider = JuditProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError) as exc_info:
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert "Timeout" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_processo_nao_encontrado_lanca_not_found(self) -> None:
+        """HTTP 404 deve lancar JuridicoNotFoundError."""
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(return_value=Response(404, json={"error": "Not found"}))
+            provider = JuditProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoNotFoundError):
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+    @pytest.mark.asyncio
+    async def test_processo_sigiloso_lanca_sigilo_error(self) -> None:
+        """Payload com nivel_sigilo > 0 deve lancar JuridicoSigiloError."""
+        payload = _payload_processo(nivel_sigilo=1)
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(return_value=Response(200, json=payload))
+            provider = JuditProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoSigiloError):
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+    @pytest.mark.asyncio
+    async def test_erro_500_lanca_api_error(self) -> None:
+        """HTTP 500 deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(return_value=Response(500, text="Internal Server Error"))
+            provider = JuditProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError):
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+
+class TestJuditProviderListarMovimentacoes:
+    """Testes de listar_movimentacoes para o JuditProvider."""
+
+    @pytest.mark.asyncio
+    async def test_lista_movimentacoes_ok(self) -> None:
+        """Happy path: retorna lista de Movimentacao."""
+        with respx.mock:
+            respx.get(JUDIT_MOV_URL).mock(return_value=Response(200, json=_payload_movimentacoes()))
+            provider = JuditProvider(api_key=API_KEY)
+            movs = await provider.listar_movimentacoes(NUMERO, TRIBUNAL, limite=20)
+
+        assert len(movs) == 2
+        assert movs[0].nome == "Despacho"
+
+    @pytest.mark.asyncio
+    async def test_movimentacoes_auth_error(self) -> None:
+        """HTTP 401 em movimentacoes deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.get(JUDIT_MOV_URL).mock(return_value=Response(401))
+            provider = JuditProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError):
+                await provider.listar_movimentacoes(NUMERO, TRIBUNAL)
+
+    @pytest.mark.asyncio
+    async def test_movimentacoes_timeout(self) -> None:
+        """Timeout em movimentacoes deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.get(JUDIT_MOV_URL).mock(side_effect=TimeoutException("timeout"))
+            provider = JuditProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError):
+                await provider.listar_movimentacoes(NUMERO, TRIBUNAL)
+
+
+class TestJuditProviderVerificarAtualizacao:
+    """Testes de verificar_atualizacao para o JuditProvider."""
+
+    @pytest.mark.asyncio
+    async def test_processo_atualizado_apos_data(self) -> None:
+        """Retorna True quando data_ultima_atualizacao e posterior a desde_iso."""
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(return_value=Response(200, json=_payload_processo()))
+            provider = JuditProvider(api_key=API_KEY)
+            resultado = await provider.verificar_atualizacao(
+                NUMERO, TRIBUNAL, "2024-01-01T00:00:00Z"
+            )
+
+        assert resultado is True
+
+    @pytest.mark.asyncio
+    async def test_processo_nao_atualizado(self) -> None:
+        """Retorna False quando data_ultima_atualizacao e anterior a desde_iso."""
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(return_value=Response(200, json=_payload_processo()))
+            provider = JuditProvider(api_key=API_KEY)
+            resultado = await provider.verificar_atualizacao(
+                NUMERO, TRIBUNAL, "2025-01-01T00:00:00Z"
+            )
+
+        assert resultado is False
+
+
+# ===========================================================================
+# ESCAVADOR
+# ===========================================================================
+
+
+class TestEscavadorProviderBuscarProcesso:
+    """Testes de buscar_processo para o EscavadorProvider."""
+
+    @pytest.mark.asyncio
+    async def test_consulta_ok_retorna_processo(self) -> None:
+        """Happy path com wrapper em 'items'."""
+        payload_escavador = {
+            "items": [
+                {
+                    **_payload_processo(),
+                    "classe": {"codigo": 7, "nome": "Procedimento Comum Civel"},
+                }
+            ]
+        }
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(return_value=Response(200, json=payload_escavador))
+            provider = EscavadorProvider(api_key=API_KEY)
+            processo = await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert processo.numero_processo == NUMERO
+        assert processo.nivel_sigilo == 0
+
+    @pytest.mark.asyncio
+    async def test_erro_auth_lanca_api_error(self) -> None:
+        """HTTP 401 deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(return_value=Response(401))
+            provider = EscavadorProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError) as exc_info:
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert exc_info.value.detail.get("status_code") == 401
+
+    @pytest.mark.asyncio
+    async def test_timeout_lanca_api_error(self) -> None:
+        """Timeout deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(side_effect=TimeoutException("timeout"))
+            provider = EscavadorProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError):
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+    @pytest.mark.asyncio
+    async def test_processo_nao_encontrado(self) -> None:
+        """HTTP 404 deve lancar JuridicoNotFoundError."""
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(return_value=Response(404))
+            provider = EscavadorProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoNotFoundError):
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+    @pytest.mark.asyncio
+    async def test_processo_sigiloso_bloqueado(self) -> None:
+        """nivel_sigilo > 0 deve lancar JuridicoSigiloError."""
+        payload = {"items": [_payload_processo(nivel_sigilo=2)]}
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(return_value=Response(200, json=payload))
+            provider = EscavadorProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoSigiloError):
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+
+class TestEscavadorProviderListarMovimentacoes:
+    """Testes de listar_movimentacoes para o EscavadorProvider."""
+
+    @pytest.mark.asyncio
+    async def test_lista_ok(self) -> None:
+        """Happy path em formato Escavador com 'items'."""
+        payload = {
+            "items": [
+                {"codigo_tpu": 22, "tipo": "Despacho", "data": "2024-06-01T12:00:00Z"},
+                {"codigo_tpu": 11, "tipo": "Distribuicao", "data": "2023-01-15T09:00:00Z"},
+            ]
+        }
+        with respx.mock:
+            respx.get(ESCAVADOR_MOV_URL).mock(return_value=Response(200, json=payload))
+            provider = EscavadorProvider(api_key=API_KEY)
+            movs = await provider.listar_movimentacoes(NUMERO, TRIBUNAL)
+
+        assert len(movs) == 2
+        assert movs[0].nome == "Despacho"
+
+    @pytest.mark.asyncio
+    async def test_auth_error(self) -> None:
+        """HTTP 401 deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.get(ESCAVADOR_MOV_URL).mock(return_value=Response(401))
+            provider = EscavadorProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError):
+                await provider.listar_movimentacoes(NUMERO, TRIBUNAL)
+
+    @pytest.mark.asyncio
+    async def test_timeout(self) -> None:
+        """Timeout deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.get(ESCAVADOR_MOV_URL).mock(side_effect=TimeoutException("timeout"))
+            provider = EscavadorProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError):
+                await provider.listar_movimentacoes(NUMERO, TRIBUNAL)
+
+
+# ===========================================================================
+# TRACKJUD
+# ===========================================================================
+
+
+class TestTrackJudProviderBuscarProcesso:
+    """Testes de buscar_processo para o TrackJudProvider."""
+
+    @pytest.mark.asyncio
+    async def test_consulta_ok_retorna_processo(self) -> None:
+        """Happy path: TrackJud usa POST com corpo JSON."""
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(return_value=Response(200, json=_payload_processo()))
+            provider = TrackJudProvider(api_key=API_KEY)
+            processo = await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert processo.numero_processo == NUMERO
+        assert processo.tribunal == TRIBUNAL
+
+    @pytest.mark.asyncio
+    async def test_erro_auth_lanca_api_error(self) -> None:
+        """HTTP 401 deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(return_value=Response(401))
+            provider = TrackJudProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError) as exc_info:
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert exc_info.value.detail.get("status_code") == 401
+
+    @pytest.mark.asyncio
+    async def test_timeout_lanca_api_error(self) -> None:
+        """Timeout deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(side_effect=TimeoutException("timeout"))
+            provider = TrackJudProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError):
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+    @pytest.mark.asyncio
+    async def test_processo_nao_encontrado(self) -> None:
+        """HTTP 404 deve lancar JuridicoNotFoundError."""
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(return_value=Response(404))
+            provider = TrackJudProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoNotFoundError):
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+    @pytest.mark.asyncio
+    async def test_processo_sigiloso_bloqueado(self) -> None:
+        """nivel_sigilo > 0 deve lancar JuridicoSigiloError."""
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(
+                return_value=Response(200, json=_payload_processo(nivel_sigilo=1))
+            )
+            provider = TrackJudProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoSigiloError):
+                await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+
+class TestTrackJudProviderListarMovimentacoes:
+    """Testes de listar_movimentacoes para o TrackJudProvider."""
+
+    @pytest.mark.asyncio
+    async def test_lista_ok(self) -> None:
+        """Happy path: retorna movimentacoes via POST."""
+        with respx.mock:
+            respx.post(TRACKJUD_MOV_URL).mock(
+                return_value=Response(200, json=_payload_movimentacoes())
+            )
+            provider = TrackJudProvider(api_key=API_KEY)
+            movs = await provider.listar_movimentacoes(NUMERO, TRIBUNAL)
+
+        assert len(movs) == 2
+
+    @pytest.mark.asyncio
+    async def test_auth_error(self) -> None:
+        """HTTP 401 deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.post(TRACKJUD_MOV_URL).mock(return_value=Response(401))
+            provider = TrackJudProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError):
+                await provider.listar_movimentacoes(NUMERO, TRIBUNAL)
+
+    @pytest.mark.asyncio
+    async def test_timeout(self) -> None:
+        """Timeout deve lancar JuridicoAPIError."""
+        with respx.mock:
+            respx.post(TRACKJUD_MOV_URL).mock(side_effect=TimeoutException("timeout"))
+            provider = TrackJudProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoAPIError):
+                await provider.listar_movimentacoes(NUMERO, TRIBUNAL)
+
+
+# ===========================================================================
+# Chave ausente
+# ===========================================================================
+
+
+class TestChaveAusente:
+    """Testes de comportamento quando JURIDICO_PROVIDER_API_KEY nao e configurada."""
+
+    def test_judit_sem_chave_lanca_api_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Instanciar JuditProvider sem chave deve lancar JuridicoAPIError."""
+        monkeypatch.delenv("JURIDICO_PROVIDER_API_KEY", raising=False)
+        with pytest.raises(JuridicoAPIError) as exc_info:
+            JuditProvider()  # sem api_key explicita
+
+        assert "JURIDICO_PROVIDER_API_KEY" in str(exc_info.value)
+
+    def test_escavador_sem_chave_lanca_api_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Instanciar EscavadorProvider sem chave deve lancar JuridicoAPIError."""
+        monkeypatch.delenv("JURIDICO_PROVIDER_API_KEY", raising=False)
+        with pytest.raises(JuridicoAPIError):
+            EscavadorProvider()
+
+    def test_trackjud_sem_chave_lanca_api_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Instanciar TrackJudProvider sem chave deve lancar JuridicoAPIError."""
+        monkeypatch.delenv("JURIDICO_PROVIDER_API_KEY", raising=False)
+        with pytest.raises(JuridicoAPIError):
+            TrackJudProvider()
+
+
+# ===========================================================================
+# Regressao: verificar_atualizacao com data invalida (HIGH-3)
+# ===========================================================================
+
+
+class TestVerificarAtualizacaoDataInvalida:
+    """Regressao HIGH-3: desde_iso malformado deve lancar JuridicoValidationError
+    (nao ValueError cru) em todos os providers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_judit_data_invalida_lanca_validation_error(self) -> None:
+        """JuditProvider.verificar_atualizacao com data malformada lanca JuridicoValidationError."""
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(return_value=Response(200, json=_payload_processo()))
+            provider = JuditProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoValidationError) as exc_info:
+                await provider.verificar_atualizacao(NUMERO, TRIBUNAL, "hoje")
+
+        assert "desde_iso" in str(exc_info.value)
+        assert "ISO 8601" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_escavador_data_invalida_lanca_validation_error(self) -> None:
+        """EscavadorProvider.verificar_atualizacao com data malformada lanca JuridicoValidationError."""
+        payload_escavador = {"items": [_payload_processo()]}
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(return_value=Response(200, json=payload_escavador))
+            provider = EscavadorProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoValidationError):
+                await provider.verificar_atualizacao(NUMERO, TRIBUNAL, "2024/06/01")
+
+    @pytest.mark.asyncio
+    async def test_trackjud_data_invalida_lanca_validation_error(self) -> None:
+        """TrackJudProvider.verificar_atualizacao com data malformada lanca JuridicoValidationError."""
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(return_value=Response(200, json=_payload_processo()))
+            provider = TrackJudProvider(api_key=API_KEY)
+            with pytest.raises(JuridicoValidationError):
+                await provider.verificar_atualizacao(NUMERO, TRIBUNAL, "nao-e-uma-data")
+
+
+# ===========================================================================
+# Regressao: verificar_atualizacao para Escavador e TrackJud (MEDIUM-3)
+# ===========================================================================
+
+
+class TestEscavadorProviderVerificarAtualizacao:
+    """Testes de verificar_atualizacao para o EscavadorProvider (cobertura MEDIUM-3)."""
+
+    @pytest.mark.asyncio
+    async def test_processo_atualizado_apos_data(self) -> None:
+        """Retorna True quando data_ultima_atualizacao e posterior a desde_iso."""
+        payload_escavador = {"items": [_payload_processo()]}
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(return_value=Response(200, json=payload_escavador))
+            provider = EscavadorProvider(api_key=API_KEY)
+            resultado = await provider.verificar_atualizacao(
+                NUMERO, TRIBUNAL, "2024-01-01T00:00:00Z"
+            )
+
+        assert resultado is True
+
+    @pytest.mark.asyncio
+    async def test_processo_nao_atualizado(self) -> None:
+        """Retorna False quando data_ultima_atualizacao e anterior a desde_iso."""
+        payload_escavador = {"items": [_payload_processo()]}
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(return_value=Response(200, json=payload_escavador))
+            provider = EscavadorProvider(api_key=API_KEY)
+            resultado = await provider.verificar_atualizacao(
+                NUMERO, TRIBUNAL, "2025-01-01T00:00:00Z"
+            )
+
+        assert resultado is False
+
+    @pytest.mark.asyncio
+    async def test_sem_data_ultima_atualizacao_retorna_false(self) -> None:
+        """Retorna False quando data_ultima_atualizacao e None no processo."""
+        payload_sem_data = {
+            "items": [
+                {
+                    **_payload_processo(),
+                    "data_ultima_atualizacao": None,
+                }
+            ]
+        }
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(return_value=Response(200, json=payload_sem_data))
+            provider = EscavadorProvider(api_key=API_KEY)
+            resultado = await provider.verificar_atualizacao(
+                NUMERO, TRIBUNAL, "2024-01-01T00:00:00Z"
+            )
+
+        assert resultado is False
+
+
+class TestTrackJudProviderVerificarAtualizacao:
+    """Testes de verificar_atualizacao para o TrackJudProvider (cobertura MEDIUM-3)."""
+
+    @pytest.mark.asyncio
+    async def test_processo_atualizado_apos_data(self) -> None:
+        """Retorna True quando data_ultima_atualizacao e posterior a desde_iso."""
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(return_value=Response(200, json=_payload_processo()))
+            provider = TrackJudProvider(api_key=API_KEY)
+            resultado = await provider.verificar_atualizacao(
+                NUMERO, TRIBUNAL, "2024-01-01T00:00:00Z"
+            )
+
+        assert resultado is True
+
+    @pytest.mark.asyncio
+    async def test_processo_nao_atualizado(self) -> None:
+        """Retorna False quando data_ultima_atualizacao e anterior a desde_iso."""
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(return_value=Response(200, json=_payload_processo()))
+            provider = TrackJudProvider(api_key=API_KEY)
+            resultado = await provider.verificar_atualizacao(
+                NUMERO, TRIBUNAL, "2025-01-01T00:00:00Z"
+            )
+
+        assert resultado is False
+
+    @pytest.mark.asyncio
+    async def test_sem_data_ultima_atualizacao_retorna_false(self) -> None:
+        """Retorna False quando data_ultima_atualizacao e None no processo."""
+        payload_sem_data = {**_payload_processo(), "data_ultima_atualizacao": None}
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(return_value=Response(200, json=payload_sem_data))
+            provider = TrackJudProvider(api_key=API_KEY)
+            resultado = await provider.verificar_atualizacao(
+                NUMERO, TRIBUNAL, "2024-01-01T00:00:00Z"
+            )
+
+        assert resultado is False
+
+
+# ===========================================================================
+# Regressao: _parse_movimentacao com data ausente (MEDIUM-2)
+# ===========================================================================
+
+
+class TestParseMovimentacaoDataAusente:
+    """Regressao MEDIUM-2: movimentacao sem data usa datetime.now() com warning."""
+
+    @pytest.mark.asyncio
+    async def test_judit_movimentacao_sem_data_usa_fallback(self) -> None:
+        """Movimentacao Judit sem data deve usar datetime.now() e emitir warning."""
+        payload = _payload_processo()
+        # Substituir data por campo ausente
+        payload["movimentacoes"] = [{"codigo": 99, "nome": "Sem Data"}]
+        with respx.mock:
+            respx.get(JUDIT_URL).mock(return_value=Response(200, json=payload))
+            provider = JuditProvider(api_key=API_KEY)
+            processo = await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        # Deve ter retornado sem lancar excecao; a movimentacao tem data definida
+        assert len(processo.movimentacoes) == 1
+        assert processo.movimentacoes[0].data_hora is not None
+
+    @pytest.mark.asyncio
+    async def test_escavador_movimentacao_sem_data_usa_fallback(self) -> None:
+        """Movimentacao Escavador sem data deve usar datetime.now() sem lancar excecao."""
+        payload = {"items": [{**_payload_processo(), "movimentacoes": [{"tipo": "Audiencia"}]}]}
+        with respx.mock:
+            respx.get(ESCAVADOR_URL).mock(return_value=Response(200, json=payload))
+            provider = EscavadorProvider(api_key=API_KEY)
+            processo = await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert len(processo.movimentacoes) == 1
+        assert processo.movimentacoes[0].data_hora is not None
+
+    @pytest.mark.asyncio
+    async def test_trackjud_movimentacao_sem_data_usa_fallback(self) -> None:
+        """Movimentacao TrackJud sem data deve usar datetime.now() sem lancar excecao."""
+        payload = {**_payload_processo(), "movimentacoes": [{"nome": "Conclusao"}]}
+        with respx.mock:
+            respx.post(TRACKJUD_URL).mock(return_value=Response(200, json=payload))
+            provider = TrackJudProvider(api_key=API_KEY)
+            processo = await provider.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert len(processo.movimentacoes) == 1
+        assert processo.movimentacoes[0].data_hora is not None

--- a/tests/test_comercial_registry.py
+++ b/tests/test_comercial_registry.py
@@ -1,0 +1,300 @@
+"""Testes do seletor de provider por configuracao de ambiente e do FallbackProvider.
+
+Cenarios cobertos:
+- JURIDICO_PROVIDER ausente ou "datajud" -> DataJudProvider
+- JURIDICO_PROVIDER=judit com chave -> FallbackProvider(Judit, DataJud)
+- JURIDICO_PROVIDER=escavador com chave -> FallbackProvider(Escavador, DataJud)
+- JURIDICO_PROVIDER=trackjud com chave -> FallbackProvider(TrackJud, DataJud)
+- JURIDICO_PROVIDER=judit sem chave -> DataJudProvider (fallback silencioso)
+- JURIDICO_PROVIDER=desconhecido -> ValueError
+- FallbackProvider: provider primario falha -> secundario responde
+- FallbackProvider: JuridicoSigiloError do primario propagada sem fallback
+- Regressao HIGH-1: JuridicoAPIError na instanciacao degrada para DataJud (esperado)
+- Regressao HIGH-1: Exception generica na instanciacao tambem degrada (com log.exception)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_juridico_brasil._core.errors import JuridicoAPIError, JuridicoSigiloError
+from mcp_juridico_brasil.comercial.registry import FallbackProvider, selecionar_provider
+from mcp_juridico_brasil.datajud.provider import DataJudProvider
+from mcp_juridico_brasil.shared.schemas import Movimentacao, Processo
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NUMERO = "00012345620238260100"
+TRIBUNAL = "TJSP"
+
+
+def _processo_fake(numero: str = NUMERO) -> Processo:
+    """Retorna um Processo minimo para uso nos testes."""
+    return Processo(
+        numero_processo=numero,
+        tribunal=TRIBUNAL,
+        nivel_sigilo=0,
+        data_ultima_atualizacao=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    )
+
+
+def _movimentacao_fake() -> Movimentacao:
+    return Movimentacao(
+        codigo=22,
+        nome="Despacho",
+        data_hora=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    )
+
+
+def _mock_provider(
+    processo: Processo | None = None,
+    movimentacoes: list[Movimentacao] | None = None,
+    verificar_resultado: bool = False,
+    raise_exc: Exception | None = None,
+) -> MagicMock:
+    """Cria um provider mock com comportamentos configurados."""
+    provider = MagicMock()
+    if raise_exc:
+        provider.buscar_processo = AsyncMock(side_effect=raise_exc)
+        provider.listar_movimentacoes = AsyncMock(side_effect=raise_exc)
+        provider.verificar_atualizacao = AsyncMock(side_effect=raise_exc)
+    else:
+        provider.buscar_processo = AsyncMock(return_value=processo or _processo_fake())
+        provider.listar_movimentacoes = AsyncMock(
+            return_value=movimentacoes or [_movimentacao_fake()]
+        )
+        provider.verificar_atualizacao = AsyncMock(return_value=verificar_resultado)
+    return provider
+
+
+# ===========================================================================
+# Testes do seletor selecionar_provider
+# ===========================================================================
+
+
+class TestSelecionarProvider:
+    """Testes unitarios do seletor por variavel de ambiente."""
+
+    def test_sem_env_retorna_datajud(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sem JURIDICO_PROVIDER, deve retornar DataJudProvider."""
+        monkeypatch.delenv("JURIDICO_PROVIDER", raising=False)
+        provider = selecionar_provider()
+        assert isinstance(provider, DataJudProvider)
+
+    def test_datajud_explicito_retorna_datajud(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JURIDICO_PROVIDER=datajud deve retornar DataJudProvider."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "datajud")
+        provider = selecionar_provider()
+        assert isinstance(provider, DataJudProvider)
+
+    def test_datajud_uppercase_retorna_datajud(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Valor em uppercase deve ser aceito (case-insensitive)."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "DATAJUD")
+        provider = selecionar_provider()
+        assert isinstance(provider, DataJudProvider)
+
+    def test_judit_com_chave_retorna_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JURIDICO_PROVIDER=judit com chave deve retornar FallbackProvider."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "judit")
+        monkeypatch.setenv("JURIDICO_PROVIDER_API_KEY", "chave-fake")
+        provider = selecionar_provider()
+        assert isinstance(provider, FallbackProvider)
+
+    def test_escavador_com_chave_retorna_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JURIDICO_PROVIDER=escavador com chave deve retornar FallbackProvider."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "escavador")
+        monkeypatch.setenv("JURIDICO_PROVIDER_API_KEY", "chave-fake")
+        provider = selecionar_provider()
+        assert isinstance(provider, FallbackProvider)
+
+    def test_trackjud_com_chave_retorna_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JURIDICO_PROVIDER=trackjud com chave deve retornar FallbackProvider."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "trackjud")
+        monkeypatch.setenv("JURIDICO_PROVIDER_API_KEY", "chave-fake")
+        provider = selecionar_provider()
+        assert isinstance(provider, FallbackProvider)
+
+    def test_judit_sem_chave_degrada_para_datajud(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JURIDICO_PROVIDER=judit sem chave deve degradar para DataJudProvider."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "judit")
+        monkeypatch.delenv("JURIDICO_PROVIDER_API_KEY", raising=False)
+        provider = selecionar_provider()
+        # Sem chave, deve usar DataJud silenciosamente
+        assert isinstance(provider, DataJudProvider)
+
+    def test_provider_desconhecido_lanca_value_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JURIDICO_PROVIDER com valor invalido deve lancar ValueError."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "desconhecido")
+        with pytest.raises(ValueError, match="desconhecido"):
+            selecionar_provider()
+
+    def test_env_com_espacos_e_tratado(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Espacos ao redor do valor devem ser ignorados."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "  datajud  ")
+        provider = selecionar_provider()
+        assert isinstance(provider, DataJudProvider)
+
+    def test_juridico_api_error_na_instanciacao_degrada_para_datajud(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regressao HIGH-1: JuridicoAPIError durante instanciacao do provider comercial
+        deve degradar silenciosamente para DataJudProvider (caso esperado - chave invalida)."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "judit")
+        monkeypatch.setenv("JURIDICO_PROVIDER_API_KEY", "chave-invalida")
+        with patch(
+            "mcp_juridico_brasil.comercial.providers.JuditProvider.__init__",
+            side_effect=JuridicoAPIError("Judit", reason="Credencial invalida"),
+        ):
+            provider = selecionar_provider()
+
+        # Deve degradar para DataJud, nao lancar excecao
+        assert isinstance(provider, DataJudProvider)
+
+    def test_exception_generica_na_instanciacao_degrada_para_datajud(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regressao HIGH-1: Exception inesperada durante instanciacao do provider comercial
+        deve tambem degradar para DataJudProvider (sem silenciar o bug - usa logger.exception)."""
+        monkeypatch.setenv("JURIDICO_PROVIDER", "judit")
+        monkeypatch.setenv("JURIDICO_PROVIDER_API_KEY", "chave-qualquer")
+        with patch(
+            "mcp_juridico_brasil.comercial.providers.JuditProvider.__init__",
+            side_effect=RuntimeError("bug inesperado"),
+        ):
+            provider = selecionar_provider()
+
+        # Deve degradar para DataJud mesmo em caso de bug
+        assert isinstance(provider, DataJudProvider)
+
+
+# ===========================================================================
+# Testes do FallbackProvider
+# ===========================================================================
+
+
+class TestFallbackProvider:
+    """Testes do mecanismo de fallback automatico."""
+
+    @pytest.mark.asyncio
+    async def test_primario_ok_nao_usa_secundario(self) -> None:
+        """Quando primario responde, secundario nao e chamado."""
+        primario = _mock_provider(processo=_processo_fake())
+        secundario = _mock_provider()
+        fp = FallbackProvider(primario, secundario)
+
+        resultado = await fp.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert resultado.numero_processo == NUMERO
+        primario.buscar_processo.assert_called_once()
+        secundario.buscar_processo.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_primario_falha_usa_secundario(self) -> None:
+        """Quando primario lanca JuridicoAPIError, secundario responde."""
+        primario = _mock_provider(raise_exc=JuridicoAPIError("Judit", 503))
+        secundario = _mock_provider(processo=_processo_fake())
+        fp = FallbackProvider(primario, secundario)
+
+        resultado = await fp.buscar_processo(NUMERO, TRIBUNAL)
+
+        assert resultado.numero_processo == NUMERO
+        secundario.buscar_processo.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_primario_timeout_usa_secundario(self) -> None:
+        """Timeout no primario ativa o secundario."""
+        from httpx import TimeoutException
+
+        primario = _mock_provider(raise_exc=TimeoutException("timeout"))
+        secundario = _mock_provider(processo=_processo_fake())
+        fp = FallbackProvider(primario, secundario)
+
+        resultado = await fp.buscar_processo(NUMERO, TRIBUNAL)
+        assert resultado.numero_processo == NUMERO
+
+    @pytest.mark.asyncio
+    async def test_sigilo_primario_propagado_sem_fallback(self) -> None:
+        """JuridicoSigiloError do primario NUNCA e silenciada pelo fallback."""
+        primario = _mock_provider(raise_exc=JuridicoSigiloError(NUMERO, nivel_sigilo=1))
+        secundario = _mock_provider(processo=_processo_fake())
+        fp = FallbackProvider(primario, secundario)
+
+        with pytest.raises(JuridicoSigiloError):
+            await fp.buscar_processo(NUMERO, TRIBUNAL)
+
+        # Secundario NUNCA deve ser chamado quando sigilo e detectado
+        secundario.buscar_processo.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_listar_movimentacoes_primario_ok(self) -> None:
+        """listar_movimentacoes usa primario quando disponivel."""
+        movs = [_movimentacao_fake()]
+        primario = _mock_provider(movimentacoes=movs)
+        secundario = _mock_provider()
+        fp = FallbackProvider(primario, secundario)
+
+        resultado = await fp.listar_movimentacoes(NUMERO, TRIBUNAL)
+        assert len(resultado) == 1
+        secundario.listar_movimentacoes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_listar_movimentacoes_fallback_ativo(self) -> None:
+        """listar_movimentacoes ativa fallback quando primario falha."""
+        movs = [_movimentacao_fake()]
+        primario = _mock_provider(raise_exc=JuridicoAPIError("Judit", 500))
+        secundario = _mock_provider(movimentacoes=movs)
+        fp = FallbackProvider(primario, secundario)
+
+        resultado = await fp.listar_movimentacoes(NUMERO, TRIBUNAL)
+        assert len(resultado) == 1
+        secundario.listar_movimentacoes.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_listar_movimentacoes_sigilo_propagado(self) -> None:
+        """JuridicoSigiloError em listar_movimentacoes nao tem fallback."""
+        primario = _mock_provider(raise_exc=JuridicoSigiloError(NUMERO, nivel_sigilo=2))
+        secundario = _mock_provider()
+        fp = FallbackProvider(primario, secundario)
+
+        with pytest.raises(JuridicoSigiloError):
+            await fp.listar_movimentacoes(NUMERO, TRIBUNAL)
+
+        secundario.listar_movimentacoes.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_verificar_atualizacao_primario_ok(self) -> None:
+        """verificar_atualizacao usa primario quando disponivel."""
+        primario = _mock_provider(verificar_resultado=True)
+        secundario = _mock_provider(verificar_resultado=False)
+        fp = FallbackProvider(primario, secundario)
+
+        resultado = await fp.verificar_atualizacao(NUMERO, TRIBUNAL, "2024-01-01T00:00:00Z")
+        assert resultado is True
+        secundario.verificar_atualizacao.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_verificar_atualizacao_fallback_ativo(self) -> None:
+        """verificar_atualizacao ativa fallback quando primario falha."""
+        primario = _mock_provider(raise_exc=JuridicoAPIError("Judit", 503))
+        secundario = _mock_provider(verificar_resultado=True)
+        fp = FallbackProvider(primario, secundario)
+
+        resultado = await fp.verificar_atualizacao(NUMERO, TRIBUNAL, "2024-01-01T00:00:00Z")
+        assert resultado is True
+
+    @pytest.mark.asyncio
+    async def test_verificar_atualizacao_sigilo_propagado(self) -> None:
+        """JuridicoSigiloError em verificar_atualizacao nao tem fallback."""
+        primario = _mock_provider(raise_exc=JuridicoSigiloError(NUMERO, nivel_sigilo=1))
+        secundario = _mock_provider(verificar_resultado=True)
+        fp = FallbackProvider(primario, secundario)
+
+        with pytest.raises(JuridicoSigiloError):
+            await fp.verificar_atualizacao(NUMERO, TRIBUNAL, "2024-01-01T00:00:00Z")
+
+        secundario.verificar_atualizacao.assert_not_called()

--- a/tests/test_comercial_webhook.py
+++ b/tests/test_comercial_webhook.py
@@ -1,0 +1,436 @@
+"""Testes do handler de webhook de movimentacao processual.
+
+Cenarios cobertos:
+- Payload valido com assinatura correta -> atualiza store
+- Assinatura invalida -> WebhookAssinaturaInvalidaError (antes de processar)
+- Payload malformado (campos obrigatorios ausentes) -> ValueError
+- Processo sigiloso no payload -> JuridicoSigiloError, store nao atualizado
+- Segredo ausente -> ValueError
+- Prefixo 'sha256=' no header e tratado corretamente
+- Store atualizado com dados da movimentacao recebida
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+import pytest
+
+from mcp_juridico_brasil._core.errors import JuridicoSigiloError
+from mcp_juridico_brasil.comercial.webhook import (
+    WebhookAssinaturaInvalidaError,
+    processar_webhook,
+)
+from mcp_juridico_brasil.monitoramento import store
+
+# ---------------------------------------------------------------------------
+# Constantes e helpers
+# ---------------------------------------------------------------------------
+
+NUMERO = "00012345620238260100"
+TRIBUNAL = "TJSP"
+SEGREDO = "segredo-hmac-de-teste"
+
+
+def _assinar(payload_bytes: bytes, segredo: str = SEGREDO) -> str:
+    """Gera assinatura HMAC-SHA256 no formato esperado pelo handler."""
+    mac = hmac.new(
+        key=segredo.encode("utf-8"),
+        msg=payload_bytes,
+        digestmod=hashlib.sha256,
+    )
+    return mac.hexdigest()
+
+
+def _payload_valido(
+    numero: str = NUMERO,
+    tribunal: str = TRIBUNAL,
+    nivel_sigilo: int = 0,
+) -> dict[str, Any]:
+    return {
+        "numero_processo": numero,
+        "tribunal": tribunal,
+        "nivel_sigilo": nivel_sigilo,
+        "data_ultima_atualizacao": "2024-06-01T12:00:00Z",
+        "movimentacoes": [
+            {
+                "codigo": 22,
+                "nome": "Despacho",
+                "data_hora": "2024-06-01T12:00:00Z",
+                "complementos": [],
+            }
+        ],
+        "metadados_provider": {"provider": "judit", "id_notificacao": "abc123"},
+    }
+
+
+def _serializar(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+
+# ===========================================================================
+# Testes de assinatura
+# ===========================================================================
+
+
+class TestWebhookAssinatura:
+    """Testes de validacao HMAC do webhook."""
+
+    def test_payload_valido_assinatura_correta_processa(self) -> None:
+        """Payload com assinatura correta deve ser processado com sucesso."""
+        payload = _payload_valido()
+        payload_bytes = _serializar(payload)
+        assinatura = _assinar(payload_bytes)
+
+        resultado = processar_webhook(
+            payload=payload,
+            assinatura_header=assinatura,
+            payload_bytes=payload_bytes,
+            webhook_secret=SEGREDO,
+        )
+
+        assert resultado["processado"] is True
+        assert resultado["numero_processo"] == NUMERO
+        assert resultado["movimentacoes_recebidas"] == 1
+
+    def test_prefixo_sha256_no_header_aceito(self) -> None:
+        """Header no formato 'sha256=<digest>' deve ser aceito."""
+        payload = _payload_valido()
+        payload_bytes = _serializar(payload)
+        assinatura = "sha256=" + _assinar(payload_bytes)
+
+        resultado = processar_webhook(
+            payload=payload,
+            assinatura_header=assinatura,
+            payload_bytes=payload_bytes,
+            webhook_secret=SEGREDO,
+        )
+
+        assert resultado["processado"] is True
+
+    def test_assinatura_errada_rejeitada(self) -> None:
+        """Assinatura incorreta deve lancar WebhookAssinaturaInvalidaError."""
+        payload = _payload_valido()
+        payload_bytes = _serializar(payload)
+        assinatura_errada = "a" * 64  # HMAC invalido
+
+        with pytest.raises(WebhookAssinaturaInvalidaError):
+            processar_webhook(
+                payload=payload,
+                assinatura_header=assinatura_errada,
+                payload_bytes=payload_bytes,
+                webhook_secret=SEGREDO,
+            )
+
+    def test_assinatura_segredo_diferente_rejeitada(self) -> None:
+        """Assinatura gerada com segredo diferente deve ser rejeitada."""
+        payload = _payload_valido()
+        payload_bytes = _serializar(payload)
+        assinatura_segredo_errado = _assinar(payload_bytes, segredo="outro-segredo")
+
+        with pytest.raises(WebhookAssinaturaInvalidaError):
+            processar_webhook(
+                payload=payload,
+                assinatura_header=assinatura_segredo_errado,
+                payload_bytes=payload_bytes,
+                webhook_secret=SEGREDO,
+            )
+
+    def test_payload_alterado_apos_assinar_rejeitado(self) -> None:
+        """Payload modificado apos assinatura deve falhar na verificacao HMAC."""
+        payload_original = _payload_valido()
+        payload_bytes_original = _serializar(payload_original)
+        assinatura = _assinar(payload_bytes_original)
+
+        # Simula payload adulterado em transito
+        payload_adulterado = {**payload_original, "tribunal": "STJ"}
+        payload_bytes_adulterado = _serializar(payload_adulterado)
+
+        with pytest.raises(WebhookAssinaturaInvalidaError):
+            processar_webhook(
+                payload=payload_adulterado,
+                assinatura_header=assinatura,
+                payload_bytes=payload_bytes_adulterado,
+                webhook_secret=SEGREDO,
+            )
+
+    def test_segredo_ausente_lanca_value_error(self) -> None:
+        """Sem segredo configurado, deve lancar ValueError antes de qualquer validacao."""
+        payload = _payload_valido()
+        payload_bytes = _serializar(payload)
+
+        with pytest.raises(ValueError, match="JURIDICO_WEBHOOK_SECRET"):
+            processar_webhook(
+                payload=payload,
+                assinatura_header="qualquer",
+                payload_bytes=payload_bytes,
+                webhook_secret=None,  # sem segredo
+            )
+
+    def test_segredo_via_env_usado_quando_parametro_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Segredo lido de JURIDICO_WEBHOOK_SECRET quando nao passado como parametro."""
+        monkeypatch.setenv("JURIDICO_WEBHOOK_SECRET", SEGREDO)
+        payload = _payload_valido()
+        payload_bytes = _serializar(payload)
+        assinatura = _assinar(payload_bytes)
+
+        resultado = processar_webhook(
+            payload=payload,
+            assinatura_header=assinatura,
+            payload_bytes=payload_bytes,
+            webhook_secret=None,  # deve ler do env
+        )
+
+        assert resultado["processado"] is True
+
+
+# ===========================================================================
+# Testes de payload
+# ===========================================================================
+
+
+class TestWebhookPayload:
+    """Testes de validacao de schema e conteudo do payload."""
+
+    def test_payload_malformado_sem_numero_processo(self) -> None:
+        """Payload sem numero_processo deve lancar ValueError apos validar assinatura."""
+        payload_invalido: dict[str, Any] = {
+            "tribunal": TRIBUNAL,
+            # numero_processo ausente
+        }
+        payload_bytes = _serializar(payload_invalido)
+        assinatura = _assinar(payload_bytes)
+
+        with pytest.raises(ValueError, match="malformado"):
+            processar_webhook(
+                payload=payload_invalido,
+                assinatura_header=assinatura,
+                payload_bytes=payload_bytes,
+                webhook_secret=SEGREDO,
+            )
+
+    def test_payload_malformado_sem_tribunal(self) -> None:
+        """Payload sem tribunal deve lancar ValueError."""
+        payload_invalido: dict[str, Any] = {
+            "numero_processo": NUMERO,
+            # tribunal ausente
+        }
+        payload_bytes = _serializar(payload_invalido)
+        assinatura = _assinar(payload_bytes)
+
+        with pytest.raises(ValueError, match="malformado"):
+            processar_webhook(
+                payload=payload_invalido,
+                assinatura_header=assinatura,
+                payload_bytes=payload_bytes,
+                webhook_secret=SEGREDO,
+            )
+
+    def test_processo_sigiloso_bloqueado(self) -> None:
+        """Payload com nivel_sigilo > 0 deve lancar JuridicoSigiloError."""
+        payload = _payload_valido(nivel_sigilo=1)
+        payload_bytes = _serializar(payload)
+        assinatura = _assinar(payload_bytes)
+
+        with pytest.raises(JuridicoSigiloError):
+            processar_webhook(
+                payload=payload,
+                assinatura_header=assinatura,
+                payload_bytes=payload_bytes,
+                webhook_secret=SEGREDO,
+            )
+
+    def test_processo_sigiloso_nao_atualiza_store(self) -> None:
+        """Processo sigiloso nao deve ser salvo no store, mesmo com assinatura valida."""
+        numero_sigiloso = "99999999920238260100"
+        # Garantir que nao existe snapshot antes
+        store.remover_snapshot(numero_sigiloso)
+
+        payload = _payload_valido(numero=numero_sigiloso, nivel_sigilo=2)
+        payload_bytes = _serializar(payload)
+        assinatura = _assinar(payload_bytes)
+
+        with pytest.raises(JuridicoSigiloError):
+            processar_webhook(
+                payload=payload,
+                assinatura_header=assinatura,
+                payload_bytes=payload_bytes,
+                webhook_secret=SEGREDO,
+            )
+
+        snapshot = store.obter_snapshot(numero_sigiloso)
+        assert snapshot is None, "Store nao deve conter processo sigiloso"
+
+    def test_payload_sem_movimentacoes_processado(self) -> None:
+        """Payload valido sem movimentacoes deve ser aceito (lista vazia permitida)."""
+        payload: dict[str, Any] = {
+            "numero_processo": NUMERO,
+            "tribunal": TRIBUNAL,
+            "nivel_sigilo": 0,
+            "movimentacoes": [],
+        }
+        payload_bytes = _serializar(payload)
+        assinatura = _assinar(payload_bytes)
+
+        resultado = processar_webhook(
+            payload=payload,
+            assinatura_header=assinatura,
+            payload_bytes=payload_bytes,
+            webhook_secret=SEGREDO,
+        )
+
+        assert resultado["processado"] is True
+        assert resultado["movimentacoes_recebidas"] == 0
+
+    def test_data_ultima_atualizacao_formato_invalido_rejeitado(self) -> None:
+        """Regressao MEDIUM-5: data_ultima_atualizacao malformada deve ser rejeitada
+        pelo schema Pydantic (AwareDatetime) antes de qualquer processamento."""
+        payload: dict[str, Any] = {
+            "numero_processo": NUMERO,
+            "tribunal": TRIBUNAL,
+            "nivel_sigilo": 0,
+            "data_ultima_atualizacao": "ontem",  # formato invalido
+            "movimentacoes": [],
+        }
+        payload_bytes = _serializar(payload)
+        assinatura = _assinar(payload_bytes)
+
+        with pytest.raises(ValueError, match="malformado"):
+            processar_webhook(
+                payload=payload,
+                assinatura_header=assinatura,
+                payload_bytes=payload_bytes,
+                webhook_secret=SEGREDO,
+            )
+
+    def test_data_ultima_atualizacao_iso_valida_aceita(self) -> None:
+        """Data ISO 8601 com fuso horario deve ser aceita pelo schema AwareDatetime."""
+        payload: dict[str, Any] = {
+            "numero_processo": NUMERO,
+            "tribunal": TRIBUNAL,
+            "nivel_sigilo": 0,
+            "data_ultima_atualizacao": "2024-06-01T12:00:00+00:00",
+            "movimentacoes": [],
+        }
+        payload_bytes = _serializar(payload)
+        assinatura = _assinar(payload_bytes)
+
+        resultado = processar_webhook(
+            payload=payload,
+            assinatura_header=assinatura,
+            payload_bytes=payload_bytes,
+            webhook_secret=SEGREDO,
+        )
+
+        assert resultado["processado"] is True
+
+
+# ===========================================================================
+# Testes de atualizacao do store
+# ===========================================================================
+
+
+class TestWebhookStore:
+    """Testes de integracao entre webhook handler e store de snapshots."""
+
+    def test_payload_valido_atualiza_store(self) -> None:
+        """Apos processar webhook, snapshot deve estar no store com dados corretos."""
+        numero_teste = "11111111120238260100"
+        store.remover_snapshot(numero_teste)
+
+        payload = _payload_valido(numero=numero_teste)
+        payload_bytes = _serializar(payload)
+        assinatura = _assinar(payload_bytes)
+
+        processar_webhook(
+            payload=payload,
+            assinatura_header=assinatura,
+            payload_bytes=payload_bytes,
+            webhook_secret=SEGREDO,
+        )
+
+        snapshot = store.obter_snapshot(numero_teste)
+        assert snapshot is not None
+        assert snapshot["numero_processo"] == numero_teste
+        assert snapshot["tribunal"] == TRIBUNAL
+        assert snapshot["dados"]["fonte"] == "webhook"
+        assert len(snapshot["dados"]["movimentacoes"]) == 1
+
+    def test_webhook_subsequente_sobrescreve_snapshot(self) -> None:
+        """Segundo webhook para o mesmo processo substitui o snapshot anterior."""
+        numero_teste = "22222222220238260100"
+        store.remover_snapshot(numero_teste)
+
+        # Primeiro webhook - 1 movimentacao
+        payload1 = _payload_valido(numero=numero_teste)
+        bytes1 = _serializar(payload1)
+        processar_webhook(
+            payload=payload1,
+            assinatura_header=_assinar(bytes1),
+            payload_bytes=bytes1,
+            webhook_secret=SEGREDO,
+        )
+
+        # Segundo webhook - 2 movimentacoes
+        payload2 = {
+            **_payload_valido(numero=numero_teste),
+            "movimentacoes": [
+                {"nome": "Sentenca", "data_hora": "2024-07-01T10:00:00Z"},
+                {"nome": "Despacho", "data_hora": "2024-06-01T12:00:00Z"},
+            ],
+        }
+        bytes2 = _serializar(payload2)
+        processar_webhook(
+            payload=payload2,
+            assinatura_header=_assinar(bytes2),
+            payload_bytes=bytes2,
+            webhook_secret=SEGREDO,
+        )
+
+        snapshot = store.obter_snapshot(numero_teste)
+        assert snapshot is not None
+        assert len(snapshot["dados"]["movimentacoes"]) == 2
+
+    def test_metadados_provider_persistidos_no_store(self) -> None:
+        """Metadados do provider devem ser salvos no snapshot para rastreabilidade."""
+        numero_teste = "33333333320238260100"
+        store.remover_snapshot(numero_teste)
+
+        payload = _payload_valido(numero=numero_teste)
+        payload["metadados_provider"] = {"provider": "judit", "id_notificacao": "xyz789"}
+        payload_bytes = _serializar(payload)
+
+        processar_webhook(
+            payload=payload,
+            assinatura_header=_assinar(payload_bytes),
+            payload_bytes=payload_bytes,
+            webhook_secret=SEGREDO,
+        )
+
+        snapshot = store.obter_snapshot(numero_teste)
+        assert snapshot is not None
+        meta = snapshot["dados"].get("metadados_provider", {})
+        assert meta.get("id_notificacao") == "xyz789"
+
+    def test_assinatura_invalida_nao_atualiza_store(self) -> None:
+        """Com assinatura invalida, store nao deve ser modificado."""
+        numero_teste = "44444444420238260100"
+        store.remover_snapshot(numero_teste)
+
+        payload = _payload_valido(numero=numero_teste)
+        payload_bytes = _serializar(payload)
+
+        with pytest.raises(WebhookAssinaturaInvalidaError):
+            processar_webhook(
+                payload=payload,
+                assinatura_header="assinatura-invalida",
+                payload_bytes=payload_bytes,
+                webhook_secret=SEGREDO,
+            )
+
+        assert store.obter_snapshot(numero_teste) is None


### PR DESCRIPTION
## Escopo

Implementa a camada de provider comercial (Fase 3) sobre a base DataJud existente.

### O que foi entregue

- **Interface `ComercialProvider`** (Strategy Pattern) - contrato abstrato para qualquer provider comercial
- **Providers mock-ready**: Judit, Escavador e TrackJud - estrutura completa, metodos implementados com respostas simuladas; integracao real pendente de credencial (ver abaixo)
- **Seletor por env var** `JURIDICO_PROVIDER` (valores aceitos: `datajud`, `judit`, `escavador`, `trackjud`) - padrao `datajud`
- **Fallback automatico para DataJud** quando o provider comercial retorna erro ou nao esta configurado
- **Registry de providers** (`comercial/registry.py`) - resolucao e registro de implementacoes em tempo de execucao
- **Handler de webhook** (`comercial/webhook.py`) - validacao de assinatura HMAC-SHA256, parsing de payload e callback configuravel
- **Testes mockados** para providers, registry e webhook (todos passando no CI)
- **`verificar_atualizacao` promovida a metodo concreto** no `ProcessoProvider` base, com implementacao padrao reutilizavel por todos os providers

### Pendente de credencial (integracao real)

Os tres providers comerciais estao mock-ready. Para ativar a integracao real, e necessario fornecer:

| Provider | Env vars necessarias |
|----------|---------------------|
| Judit | `JUDIT_API_KEY`, `JUDIT_BASE_URL` |
| Escavador | `ESCAVADOR_API_KEY`, `ESCAVADOR_BASE_URL` |
| TrackJud | `TRACKJUD_TOKEN`, `TRACKJUD_BASE_URL` |

Sem essas variaveis, o sistema usa automaticamente o fallback DataJud.

## Checklist

- [x] ruff check - sem erros
- [x] mypy src - 31 arquivos, sem erros
- [x] pytest - 174 testes passando
- [x] Commit unico, mensagem descritiva
- [x] Sem credenciais hardcoded
- [x] Docstrings e comentarios em pt-BR