### PR TITLE
fix: data_hora invalida vira error (nao warning) nos providers comerciais

### DIFF
--- a/src/mcp_juridico_brasil/comercial/providers.py
+++ b/src/mcp_juridico_brasil/comercial/providers.py
@@ -118,6 +118,10 @@ class JuditProvider(ProcessoProvider):
     def __init__(self, api_key: str | None = None) -> None:
         self._api_key = api_key or _exigir_api_key("Judit")
         self._base_url = _JUDIT_BASE_URL
+        # TODO: substituir por client compartilhado por instancia (httpx.AsyncClient
+        # no __init__ + aclose() no ciclo de vida) para habilitar connection pooling
+        # e reduzir overhead de handshake TLS por chamada. Impacto aceitavel no
+        # volume atual, mas necessario antes de escalar para producao com alto RPS.
 
     def _headers(self) -> dict[str, str]:
         return {
@@ -263,10 +267,15 @@ class JuditProvider(ProcessoProvider):
         data_raw = data.get("data_hora", data.get("dataHora", data.get("data", "")))
         dt = _iso_ou_none(str(data_raw))
         if dt is None:
-            logger.warning(
-                "movimentacao_sem_data_usando_now",
+            # ATENCAO: data_hora ausente ou malformada. Usamos datetime.now como
+            # placeholder para satisfazer o schema nao-nullable, mas esse valor e
+            # INCORRETO para calculo de prazos. Logar como erro para visibilidade.
+            # TODO: quando Movimentacao.data_hora aceitar Optional[datetime], retornar None.
+            logger.error(
+                "movimentacao_data_invalida_usando_now",
                 provider="judit",
                 codigo=data.get("codigo"),
+                data_raw=str(data_raw)[:80],
             )
             dt = datetime.now(tz=timezone.utc)
         return Movimentacao(
@@ -453,10 +462,15 @@ class EscavadorProvider(ProcessoProvider):
         data_raw = data.get("data", data.get("data_hora", ""))
         dt = _iso_ou_none(str(data_raw))
         if dt is None:
-            logger.warning(
-                "movimentacao_sem_data_usando_now",
+            # ATENCAO: data_hora ausente ou malformada. Usamos datetime.now como
+            # placeholder para satisfazer o schema nao-nullable, mas esse valor e
+            # INCORRETO para calculo de prazos. Logar como erro para visibilidade.
+            # TODO: quando Movimentacao.data_hora aceitar Optional[datetime], retornar None.
+            logger.error(
+                "movimentacao_data_invalida_usando_now",
                 provider="escavador",
                 codigo=data.get("codigo_tpu"),
+                data_raw=str(data_raw)[:80],
             )
             dt = datetime.now(tz=timezone.utc)
         return Movimentacao(
@@ -635,10 +649,15 @@ class TrackJudProvider(ProcessoProvider):
         data_raw = data.get("data_hora", data.get("data", ""))
         dt = _iso_ou_none(str(data_raw))
         if dt is None:
-            logger.warning(
-                "movimentacao_sem_data_usando_now",
+            # ATENCAO: data_hora ausente ou malformada. Usamos datetime.now como
+            # placeholder para satisfazer o schema nao-nullable, mas esse valor e
+            # INCORRETO para calculo de prazos. Logar como erro para visibilidade.
+            # TODO: quando Movimentacao.data_hora aceitar Optional[datetime], retornar None.
+            logger.error(
+                "movimentacao_data_invalida_usando_now",
                 provider="trackjud",
                 codigo=data.get("codigo"),
+                data_raw=str(data_raw)[:80],
             )
             dt = datetime.now(tz=timezone.utc)
         return Movimentacao(


### PR DESCRIPTION
## Escopo

Correcao de qualidade pos-Fase 3 nos providers comerciais (`providers.py`).

## Mudancas

- `_parse_movimentacao` (Judit, Escavador, TrackJud): `logger.warning` promovido
  para `logger.error` quando `data_hora` e ausente ou malformada, com campo
  `data_raw` no log para diagnostico
- Comentario TODO em `JuditProvider.__init__` documentando httpx client
  compartilhado como melhoria de performance para producao com alto RPS

## Motivacao

`data_hora` invalida resulta em `datetime.now(tz=timezone.utc)` como fallback,
que distorce calculo de prazos juridicos. O nivel `warning` era insuficiente
para detectar esse dado corrompido em stacks de observabilidade. Nivel `error`
garante alerta automatico em qualquer sistema de monitoramento padrao.

## Pendencias conhecidas (nao alteradas neste PR)

- `Movimentacao.data_hora: datetime` permanece nao-nullable (schema Pydantic).
  Para retornar `None` de forma correta seria necessario alterar o schema e
  todos os consumidores - escopo de uma issue separada.
- httpx client por chamada (sem pooling): aceitavel no volume atual, documentado
  com TODO para quando houver necessidade de escala.
- Integracao real dos 3 providers comerciais depende de credencial de producao.