### PR TITLE
fix: corrige vulnerabilidades de dependências (auditoria supply chain)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ dependencies = [
     "structlog>=25.5.0",
     "typer>=0.25.1",
     "workalendar>=17.0.0",
+    "cryptography>=50.0.0",
+    "mcp>=1.28.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Auditoria de supply chain (2026-08-22)

Atualização de dependências vulneráveis identificadas por `npm audit` / `pnpm audit` / `pip-audit`. Escopo mínimo: só arquivos de dependência e o estritamente necessário para build/testes.

### Pacotes alterados
- cryptography: 49.0.0 -> 50.0.0
- mcp: 1.28.0 -> 1.29.0

### Gates executados
- **lint**: OK - ruff check src tests: All checks passed! / ruff format --check: 47 files already formatted
- **typecheck**: OK - mypy src: Success: no issues found in 36 source files
- **tests**: OK - uv run pytest: 231 passed, 1 warning (DeprecationWarning não relacionado em opentelemetry) em 5.68s
- **build**: OK - uv build: sdist e wheel mcp_juridico_brasil-0.1.0 gerados sem erro (versão do pacote não alterada, conforme pedido)
- **audit_final**: OK - uvx pip-audit --no-deps -r <export uv sem -e .>: No known vulnerabilities found

### O que ficou de fora e por quê
Nenhum finding sobrou. cryptography e mcp não eram dependências diretas no pyproject.toml original (cryptography é transitivo via authlib/joserfc/secretstorage; mcp é transitivo via fastmcp) - foram adicionados como entradas diretas em [project].dependencies (cryptography>=50.0.0, mcp>=1.28.1) para fixar o piso mínimo exigido, e uv lock --upgrade-package resolveu apenas esses dois pacotes (upgrade cirúrgico, resto do lock intacto). uv.lock é gitignored neste repo (.gitignore tem a linha "uv.lock"), então não aparece no diff nem no commit - só pyproject.toml foi versionado, que é o comportamento correto e já existente do repo antes desta tarefa.

### Riscos e observações
git fetch origin deu timeout (exit 124) apos 40s - branch criada a partir da main local (dcc1e4d), nao da origin/main. Nao ha risco de divergencia visivel: git worktree list mostrava so a main local antes, sem sinal de remote desatualizado, mas vale o time lead confirmar que a main local esta em dia com origin antes de abrir PR. uv.lock nao e versionado neste repo (esta no .gitignore de proposito), entao quem rodar uv sync a partir do pyproject.toml atualizado vai resolver as versoes mais recentes compativeis (incluindo cryptography>=50.0.0 e mcp>=1.28.1) automaticamente; nao ha lockfile desatualizado para reconciliar. Nenhum breaking change observado nos 231 testes, lint ou typecheck. Nenhum segredo tocado, nenhum arquivo fora do escopo modificado.
