### PR TITLE
fix(datajud): deduz tribunal do CNJ + nits de review (#20)

### DIFF
--- a/src/mcp_juridico_brasil/datajud/client.py
+++ b/src/mcp_juridico_brasil/datajud/client.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+import httpx
+
 from mcp_juridico_brasil._core import (
     HTTPClient,
     JuridicoAPIError,
@@ -25,7 +27,7 @@ from mcp_juridico_brasil._core import (
 )
 from mcp_juridico_brasil.shared.schemas import Assunto, Movimentacao, OrgaoJulgador, Parte, Processo
 
-from .tribunais import indice_para_url, listar_tribunais
+from .tribunais import indice_para_url, listar_tribunais, sigla_por_numero_cnj
 
 logger = get_logger(__name__)
 
@@ -60,7 +62,17 @@ class DataJudClient:
         """
         query = {"query": {"match": {"numeroProcesso": numero_processo}}, "size": 1}
         async with self._http(tribunal) as client:
-            data = await client.post("", json=query)
+            try:
+                data = await client.post("", json=query)
+            except httpx.HTTPStatusError as exc:
+                # O metodo documenta JuridicoAPIError para falhas de
+                # comunicacao; sem esta conversao a HTTPStatusError crua
+                # escapava e abortava a varredura multi-tribunal.
+                raise JuridicoAPIError(
+                    source="DataJud",
+                    status_code=exc.response.status_code,
+                    reason=f"Consulta ao indice do tribunal '{tribunal}' falhou.",
+                ) from exc
 
         hits = data.get("hits", {}).get("hits", [])
         if not hits:
@@ -79,7 +91,16 @@ class DataJudClient:
         Itera pelos tribunais informados (ou por todos os suportados) até
         encontrar o processo.
         """
-        targets = tribunais or listar_tribunais()
+        if tribunais:
+            targets = tribunais
+        else:
+            targets = listar_tribunais()
+            # O proprio numero CNJ identifica o tribunal (segmentos J e TR):
+            # tentar por ele primeiro resolve em 1 requisicao em vez de ate 91.
+            provavel = sigla_por_numero_cnj(numero_processo)
+            if provavel:
+                targets = [provavel] + [t for t in targets if t != provavel]
+
         last_error: Exception | None = None
         for tribunal in targets:
             try:

--- a/src/mcp_juridico_brasil/datajud/tribunais.py
+++ b/src/mcp_juridico_brasil/datajud/tribunais.py
@@ -87,6 +87,78 @@ TRIBUNAIS: dict[str, str] = {
 }
 
 
+# Mapa: codigo TR (2 digitos) -> UF, conforme a ordem alfabetica dos estados
+# definida na Res. CNJ 65/2008 para a Justica Estadual e Eleitoral.
+_TR_PARA_UF: dict[str, str] = {
+    "01": "AC",
+    "02": "AL",
+    "03": "AP",
+    "04": "AM",
+    "05": "BA",
+    "06": "CE",
+    "07": "DF",
+    "08": "ES",
+    "09": "GO",
+    "10": "MA",
+    "11": "MT",
+    "12": "MS",
+    "13": "MG",
+    "14": "PA",
+    "15": "PB",
+    "16": "PR",
+    "17": "PE",
+    "18": "PI",
+    "19": "RJ",
+    "20": "RN",
+    "21": "RS",
+    "22": "RO",
+    "23": "RR",
+    "24": "SC",
+    "25": "SE",
+    "26": "SP",
+    "27": "TO",
+}
+
+
+def sigla_por_numero_cnj(numero_processo: str) -> str | None:
+    """Deduz a sigla do tribunal a partir do numero CNJ.
+
+    O formato NNNNNNN-DD.AAAA.J.TR.OOOO (Res. CNJ 65/2008) ja identifica o
+    tribunal: J e o segmento do Judiciario e TR o codigo do tribunal. Deduzir
+    daqui evita varrer os 91 indices quando o tribunal nao foi informado.
+
+    Retorna None quando o numero e invalido ou quando o tribunal deduzido nao
+    esta no mapa de indices -- nesse caso o chamador deve manter o fallback.
+    """
+    digitos = "".join(c for c in numero_processo if c.isdigit())
+    if len(digitos) != 20:
+        return None
+
+    j, tr = digitos[13], digitos[14:16]
+    uf = _TR_PARA_UF.get(tr)
+
+    if j == "1":
+        sigla = "STF" if tr == "00" else None
+    elif j == "3":
+        sigla = "STJ" if tr == "00" else None
+    elif j == "4":
+        sigla = f"TRF{int(tr)}" if tr != "00" else None
+    elif j == "5":
+        sigla = "TST" if tr == "00" else f"TRT{int(tr)}"
+    elif j == "6":
+        sigla = "TSE" if tr == "00" else (f"TRE{uf}" if uf else None)
+    elif j == "7":
+        sigla = "STM"
+    elif j == "8":
+        sigla = "TJDFT" if tr == "07" else (f"TJ{uf}" if uf else None)
+    elif j == "9":
+        sigla = f"TJM{uf}" if uf else None
+    else:
+        return None
+
+    return sigla if sigla in TRIBUNAIS else None
+
+
 def sigla_para_indice(sigla: str) -> str | None:
     """Converte sigla do tribunal para o sufixo do indice DataJud."""
     return TRIBUNAIS.get(sigla.upper())
@@ -105,4 +177,10 @@ def listar_tribunais() -> list[str]:
     return sorted(TRIBUNAIS.keys())
 
 
-__all__ = ["TRIBUNAIS", "indice_para_url", "listar_tribunais", "sigla_para_indice"]
+__all__ = [
+    "TRIBUNAIS",
+    "indice_para_url",
+    "listar_tribunais",
+    "sigla_para_indice",
+    "sigla_por_numero_cnj",
+]

--- a/tests/test_datajud_cnj_deduction.py
+++ b/tests/test_datajud_cnj_deduction.py
@@ -1,0 +1,71 @@
+"""Testes da deducao de tribunal pelo numero CNJ (DataJud)."""
+
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response
+
+from mcp_juridico_brasil._core.errors import JuridicoAPIError
+from mcp_juridico_brasil.datajud.client import DataJudClient
+
+# Reusa helpers do modulo principal de testes DataJud.
+from tests.test_datajud_client import BASE_URL, _resp_processo_publico
+
+
+@pytest.mark.parametrize(
+    ("numero", "esperado"),
+    [
+        ("1000077-34.2026.8.13.0166", "TJMG"),  # Justica Estadual - MG
+        ("0002150-34.2023.8.26.0100", "TJSP"),  # Justica Estadual - SP
+        ("0001234-56.2023.8.07.0001", "TJDFT"),  # DF usa sigla propria
+        ("0001234-56.2023.4.03.6100", "TRF3"),  # Justica Federal
+        ("0001234-56.2023.5.03.0001", "TRT3"),  # Justica do Trabalho
+        ("0001234-56.2023.1.00.0000", "STF"),  # Tribunal Superior
+        ("0001234-56.2023.3.00.0000", "STJ"),  # STJ exige TR=00
+        ("0001234-56.2023.1.01.0000", None),  # STF so com TR=00
+        ("0001234-56.2023.3.01.0000", None),  # STJ so com TR=00
+        ("0001234-56.2023.7.01.0000", "STM"),  # STM mantem indice unico
+        ("00012345620238130024", "TJMG"),  # aceita sem mascara
+        ("numero invalido", None),  # nao explode
+        ("0001234-56.2023.0.99.0001", None),  # segmento inexistente
+    ],
+)
+def test_sigla_por_numero_cnj(numero: str, esperado: str | None) -> None:
+    from mcp_juridico_brasil.datajud.tribunais import sigla_por_numero_cnj
+
+    assert sigla_por_numero_cnj(numero) == esperado
+
+
+@pytest.mark.asyncio
+async def test_multiplos_tribunais_tenta_o_tribunal_do_numero_primeiro() -> None:
+    """O numero CNJ ja diz o tribunal: deve resolver em 1 requisicao."""
+    numero = "10000773420268130166"  # 8.13 => TJMG
+
+    with respx.mock:
+        rota_mg = respx.post(f"{BASE_URL}/api_publica_tjmg/_search/").mock(
+            return_value=Response(200, json=_resp_processo_publico(numero=numero))
+        )
+        # Antes da correcao a varredura comecava pelo STF (ordem alfabetica).
+        rota_stf = respx.post(f"{BASE_URL}/api_publica_stf/_search/").mock(
+            return_value=Response(404)
+        )
+        processo = await DataJudClient().buscar_por_numero_multiplos_tribunais(numero)
+
+    assert processo.numero_processo == numero
+    assert rota_mg.call_count == 1
+    assert rota_stf.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_404_em_um_tribunal_nao_aborta_a_varredura() -> None:
+    """HTTP 404 num indice virava HTTPStatusError crua e matava a busca."""
+    numero = "00012345620230990001"  # segmento sem tribunal deduzivel
+
+    with respx.mock:
+        respx.post(url__regex=rf"{BASE_URL}/api_publica_\w+/_search/").mock(
+            return_value=Response(404)
+        )
+        with pytest.raises(JuridicoAPIError) as exc_info:
+            await DataJudClient().buscar_por_numero_multiplos_tribunais(numero)
+        assert exc_info.value.detail.get("status_code") == 404


### PR DESCRIPTION
Lands the fix from fork PR #20 (thanks @aguillar2) plus the review nits from 2026-09-09.

## Why a follow-up PR

Could not push to the fork head (`aguillar2:fix/deduzir-tribunal-do-numero-cnj`) via API despite `maintainer_can_modify` (Contents/Git Data API returns 404). Mac `gh`/`git` machine routing was unavailable from this agent box. This branch applies the same functional change on `DeHor-Labs` so we can get green CI and merge.

## Changes

1. **`sigla_por_numero_cnj`** — deduce tribunal from CNJ `J`/`TR` and try it first in multi-tribunal search.
2. **`JuridicoAPIError(status_code=...)`** — preserve HTTP status from `HTTPStatusError` (nit 1).
3. **STF/STJ only if `TR == "00"`** — STM mapping unchanged per review (nit 2).
4. **Tests** — CNJ deduction, first-tribunal priority, 404 does not abort scan, `detail["status_code"] == 404`.
5. **ruff format** — fixes the format failures seen on #20 CI.

Closes #19. Supersedes #20.

Local: `ruff check` / `ruff format --check` / `mypy src/` clean; focused tests green.